### PR TITLE
Swap to using EDID displays

### DIFF
--- a/src/displays.rs
+++ b/src/displays.rs
@@ -69,10 +69,7 @@ pub fn get_displays() -> Vec<DisplayInfo> {
     let mut displays: Vec<DisplayInfo> = Vec::new();
 
     // (Thanks to FastFetch's SC for hinting the existance of edid to me and https://www.extron.com/article/uedid for a actual explanation for what it is)
-    // - Find all /sys/class/drm/card-* folders
-    // - Check for a "enabled" file and ensure it reads "enabled"
-    // - "status" file gives if it's connected or not
-    // - if it is connected, go into "edid" and parse it
+    // And to address the elephant in the room, yes this is a cheap and not technically correct way to do this. Unfortunately I don't have the knowledge, time nor patience to write a display server connection just for some resolution details.
 
     // Find all /sys/class/drm/ folders and scan for any that read card*-*
     let dir: ReadDir = match read_dir("/sys/class/drm") {
@@ -135,6 +132,12 @@ pub fn get_displays() -> Vec<DisplayInfo> {
                 continue
             },
         };
+        if edid_bytes.len() == 0 {
+            // This can happen in VM's, meaning no display output. Cus of this, I just push the
+            // display empty
+            displays.push(display);
+            continue
+        }
 
         // DTD starts at byte 54
         // Formula thanks to https://stackoverflow.com/a/10299885 and https://stackoverflow.com/a/4476144

--- a/src/displays.rs
+++ b/src/displays.rs
@@ -129,7 +129,6 @@ pub fn get_displays() -> Vec<DisplayInfo> {
         // The only disadvantage here is that we can't get the *current* resolution, only the max
         // res but I'm fine with that
 
-        println!("{:?}", path.join("edid"));
         let edid_bytes: Vec<u8> = match fs::read(path.join("edid")) {
             Ok(r) => r,
             Err(_) => {
@@ -147,18 +146,10 @@ pub fn get_displays() -> Vec<DisplayInfo> {
         // Refresh rate now, this is grabbed from the Pixel Clock
         // Credit for the formula: https://electronics.stackexchange.com/a/492180
         let pixel_clock: u64 = u64::from(edid_bytes[54]) << 8 | u64::from(edid_bytes[55]) * 10000000;
-
-        // Total horizontal blanking
-        let blanking_w: u32 = (u32::from(edid_bytes[63]) | u32::from((edid_bytes[65]) & 0b00110000) << 4) +     // Pulse Width
-            (u32::from(edid_bytes[57]) | (u32::from(edid_bytes[58]) & 0b00001111) << 8) +                       // Horizontal Blanking
-            (u32::from(edid_bytes[62]) | u32::from(edid_bytes[65] >> 6));                                       // Front Porch
-
-        let blanking_h: u32 = (u32::from(edid_bytes[64] & 0b0000) | u32::from(edid_bytes[65] & 0b00000011) << 4) +      // Pulse Width
-            (u32::from(edid_bytes[60]) | (u32::from(edid_bytes[61]) & 0b00001111) << 8) +                               // Vertical Blanking
-            (u32::from(edid_bytes[64] >> 4) | u32::from(edid_bytes[65] & 0b00001100) << 2);                             // Front Porch
+        let blanking_w: u32 = u32::from(edid_bytes[57]) | (u32::from(edid_bytes[58]) & 0b00001111) << 8;
+        let blanking_h: u32 = u32::from(edid_bytes[60]) | (u32::from(edid_bytes[61]) & 0b00001111) << 8;
 
         let total_pixels: u64 = (resolution_w as u64 + blanking_w as u64) * (resolution_h as u64 + blanking_h as u64);
-        // println!("{}", blanking_percent * 100.0);
         let refresh_rate: u32 = (pixel_clock / total_pixels) as u32;
         display.refresh_rate = refresh_rate;
 


### PR DESCRIPTION
This is mainly to improve performance and compatibility between DE's. Instead of relying on randr tools or going as far as to make WM connections just to query some monitor data. 
Instead I'm now parsing it from the monitor's edid data. This comes at the disadvantage obviously that data will be correct but not what the user is currently running, but until I have time to implement the more complicated solutions that are more accurate, this is the best I can do. College sucks.
