### PR TITLE
Use Compositors to get Display module info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "sqlite",
+ "wayland-client",
  "x11rb",
 ]
 
@@ -280,6 +281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +297,12 @@ checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "equivalent"
@@ -399,6 +415,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libloading"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "libredox"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +446,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
@@ -526,6 +558,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "serde"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +701,12 @@ checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
 dependencies = [
  "dirs",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sqlite"
@@ -806,6 +859,54 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e9e6b6d4a2bb4e7e69433e0b35c7923b95d4dc8503a84d25ec917a4bbfdf07"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e63801c85358a431f986cffa74ba9599ff571fc5774ac113ed3b490c19a1133"
+dependencies = [
+ "bitflags 2.4.2",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67da50b9f80159dec0ea4c11c13e24ef9e7574bd6ce24b01860a175010cea565"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105b1842da6554f91526c14a2a2172897b7f745a805d62af4ce698706be79c12"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "sqlite",
+ "x11rb",
 ]
 
 [[package]]
@@ -294,6 +295,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +312,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -393,6 +414,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "memchr"
@@ -547,6 +574,19 @@ checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -929,6 +969,23 @@ checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ serde_json = "1.0.114"
 sqlite = "0.34.0"
 libc = "0.2.153"
 humantime = "2.1.0"
+x11rb = {version = "0.13.1", features=["randr"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ sqlite = "0.34.0"
 libc = "0.2.153"
 humantime = "2.1.0"
 x11rb = {version = "0.13.1", features=["randr"]}
+wayland-client = "0.31.3"

--- a/default-config.toml
+++ b/default-config.toml
@@ -175,10 +175,11 @@ title = "Host"
 title = "Display {name}"
 
 # The format each display should be in. Placeholders;
-# {name} -> The monitor name, e.g eDP-2
+# {name} -> The monitor "name", e.g eDP-2 for Wayland and 412 for x11.
 # {width} -> The monitor's width
 # {height} -> The monitor's height
-format = "{width}x{height}"
+# {refresh_rate} -> The monitor's refresh rate. This won't work in x11!
+format = "{width}x{height} @ {refresh_rate} hz"
 
 
 [os]

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -246,7 +246,7 @@ pub fn parse(location_override: &Option<String>, module_override: &Option<String
     builder = builder.set_default("host.title", "Host").unwrap();
 
     builder = builder.set_default("displays.title", "Display {name}").unwrap();
-    builder = builder.set_default("displays.format", "{width}x{height}").unwrap();
+    builder = builder.set_default("displays.format", "{width}x{height} @ {refresh_rate} hz").unwrap();
 
     builder = builder.set_default("os.title", "Operating System").unwrap();
     builder = builder.set_default("os.format", "{distro} ({kernel})").unwrap();
@@ -568,11 +568,11 @@ title = "Host"
 title = "Display {name}"
 
 # The format each display should be in. Placeholders;
-# {name} -> The monitor name, e.g eDP-2
+# {name} -> The monitor "name", e.g eDP-2 for Wayland and 412 for x11.
 # {width} -> The monitor's width
 # {height} -> The monitor's height
-format = "{width}x{height}"
-
+# {refresh_rate} -> The monitor's refresh rate. This won't work in x11!
+format = "{width}x{height} @ {refresh_rate} hz"
 
 [os]
 title = "Operating System"

--- a/src/displays.rs
+++ b/src/displays.rs
@@ -169,11 +169,18 @@ impl Dispatch<wl_output::WlOutput, ()> for WaylandState {
             display.name = name.to_string();
         }
         if let wl_output::Event::Mode { width, height, refresh, .. } = &event {
-            display.width = width.to_string().parse::<u16>().unwrap();
-            display.height = height.to_string().parse::<u16>().unwrap();
+            display.width = match width.to_string().parse::<u16>() {
+                Ok(r) => r,
+                Err(_) => 0
+            };
+            display.height = match height.to_string().parse::<u16>() {
+                Ok(r) => r,
+                Err(_) => 0
+            };
             display.refresh_rate = match (*refresh as f32 / 1000.0).round().to_string().parse::<u16>() {
                 Ok(r) => Some(r),
                 // There's no real "error handling" here so just set it to 0 so it's not None and letting us get stuck in an infinite loop
+                // Clearly your compositor is very very very dumb
                 Err(_) => Some(0)
             };
         }

--- a/src/displays.rs
+++ b/src/displays.rs
@@ -227,10 +227,5 @@ fn fetch_wayland() -> Result<Vec<DisplayInfo>, ModuleError> {
         }
     }
 
-    // TODO: Clean this lol
-    let mut y: Vec<DisplayInfo> = Vec::new();
-    for x in data.outputs {
-        y.push(x.1.clone());
-    }
-    Ok(y)
+    Ok(data.outputs.into_iter().map(|x| x.1.clone()).collect())
 }

--- a/src/displays.rs
+++ b/src/displays.rs
@@ -184,6 +184,7 @@ fn fetch_xorg() -> Result<Vec<DisplayInfo>, ModuleError> {
 
     // Not error checked as it's not a huge problem if this fails, moreso just a "would be nice to do" thing
     let _ = conn.destroy_window(win_id);
+    displays.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
     Ok(displays)
 }
 
@@ -299,5 +300,7 @@ fn fetch_wayland() -> Result<Vec<DisplayInfo>, ModuleError> {
         }
     }
 
-    Ok(data.outputs.into_iter().map(|x| x.1.clone()).collect())
+    let mut displays: Vec<DisplayInfo> = data.outputs.into_iter().map(|x| x.1.clone()).collect();
+    displays.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    Ok(displays)
 }

--- a/src/displays.rs
+++ b/src/displays.rs
@@ -1,7 +1,8 @@
 use core::str;
-use std::env;
+use std::{collections::HashMap, env};
 
 use serde::Deserialize;
+use wayland_client::{protocol::{wl_output, wl_registry}, ConnectError, Connection, Dispatch, QueueHandle};
 use x11rb::{connection::RequestConnection, protocol::{randr::{self, MonitorInfo}, xproto::{ConnectionExt, CreateWindowAux, Screen, Window, WindowClass}}, COPY_DEPTH_FROM_PARENT};
 
 use crate::{config_manager::{Configuration, CrabFetchColor}, Module, ModuleError};
@@ -77,13 +78,14 @@ pub fn get_displays() -> Result<Vec<DisplayInfo>, ModuleError> {
     // Instead of relying on XDG_SESSION_TYPE line Desktop, I simply just check the sockets as it
     // can report any string and break if someone's dumb enough to do that
     if env::var("WAYLAND_DISPLAY").is_ok() {
-        todo!();
+        return fetch_wayland();
     } else if env::var("DISPLAY").is_ok() {
         return fetch_xorg();
     } else {
         return Err(ModuleError::new("Display", format!("Could not identify desktop session type.")));
     }
 }
+
 
 fn fetch_xorg() -> Result<Vec<DisplayInfo>, ModuleError> {
     // This has really opened my eyes as to why more pieces of software haven't swapped over to
@@ -133,4 +135,102 @@ fn fetch_xorg() -> Result<Vec<DisplayInfo>, ModuleError> {
     // Not error checked as it's not a huge problem if this fails, moreso just a "would be nice to do" thing
     let _ = conn.destroy_window(win_id);
     Ok(displays)
+}
+
+
+
+//
+// The Wayland Zone
+//
+struct WaylandState {
+    complete: bool, // Tells us whether to break out of the event loop or not
+    num_outputs: u8, // How many outputs are waiting to be processed 
+    outputs: HashMap<wl_output::WlOutput, DisplayInfo> // The output data as it stands
+}
+impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
+    fn event(state: &mut Self, reg: &wl_registry::WlRegistry, event: wl_registry::Event, _: &(), _: &Connection, qh: &QueueHandle<WaylandState>,) {
+        if let wl_registry::Event::Global {name, interface, version} = event {
+            if interface == "wl_output" {
+                // This is what we're looking for, bind to it
+                reg.bind::<wl_output::WlOutput, _, _>(name, version, &qh, ());
+                state.num_outputs += 1;   
+            }
+        }
+    }
+}
+impl Dispatch<wl_output::WlOutput, ()> for WaylandState {
+    fn event(state: &mut Self, output: &wl_output::WlOutput, event: wl_output::Event, _: &(), _: &Connection, _qh: &QueueHandle<WaylandState>,) {
+        if !state.outputs.contains_key(output) {
+            state.outputs.insert(output.clone(), DisplayInfo::new());
+        }
+
+        let display: &mut DisplayInfo = state.outputs.get_mut(output).unwrap();
+        if let wl_output::Event::Name {name} = &event {
+            display.name = name.to_string();
+        }
+        if let wl_output::Event::Mode { width, height, refresh, .. } = &event {
+            display.width = width.to_string().parse::<u16>().unwrap();
+            display.height = height.to_string().parse::<u16>().unwrap();
+            display.refresh_rate = match (*refresh as f32 / 1000.0).round().to_string().parse::<u16>() {
+                Ok(r) => Some(r),
+                // There's no real "error handling" here so just set it to 0 so it's not None and letting us get stuck in an infinite loop
+                Err(_) => Some(0)
+            };
+        }
+
+        if !display.name.is_empty() && display.width != 0 && display.height != 0 && display.refresh_rate.is_some() {
+            // We're done, release it 
+            output.release();
+            if state.num_outputs == 0 {
+                state.complete = true;
+                return;
+            }
+            state.num_outputs -= 1;
+        }
+    }
+}
+fn fetch_wayland() -> Result<Vec<DisplayInfo>, ModuleError> {
+    let conn: Connection = match Connection::connect_to_env() {
+        Ok(r) => r,
+        Err(e) => {
+            let msg: &str = match e {
+                ConnectError::NoWaylandLib => "Unable to load the Wayland library.",
+                ConnectError::NoCompositor => "Unable to find a Wayland compositor.",
+                ConnectError::InvalidFd => "Found a Wayland compositor, but the socket contained garbage."
+            };
+            return Err(ModuleError::new("Display", format!("Failed to connect to Wayland compositor: {}", msg)));
+        },
+    };
+    let display = conn.display();
+
+    let mut event_queue = conn.new_event_queue();
+    let qh = event_queue.handle();
+
+    let _registry = display.get_registry(&qh, ());
+    let mut data: WaylandState = WaylandState {
+        complete: false,
+        num_outputs: 0,
+        outputs: HashMap::new()
+    };
+
+    let mut loops: u16 = 0;
+    while !data.complete {
+        match event_queue.roundtrip(&mut data) {
+            Ok(r) => r,
+            Err(e) => {
+                return Err(ModuleError::new("Display", format!("Compositor roundtrip returned error: {}", e)));
+            }
+        };
+        loops += 1;
+        if loops > 1000 {
+            return Err(ModuleError::new("Display", "Wayland compositor took too long to respond; over 1000 event loops have passed.".to_string()));
+        }
+    }
+
+    // TODO: Clean this lol
+    let mut y: Vec<DisplayInfo> = Vec::new();
+    for x in data.outputs {
+        y.push(x.1.clone());
+    }
+    Ok(y)
 }

--- a/src/displays.rs
+++ b/src/displays.rs
@@ -220,14 +220,12 @@ impl Dispatch<wl_output::WlOutput, ()> for WaylandState {
             display.name = name.to_string();
         }
         if let wl_output::Event::Geometry {transform, ..} = &event {
-            if display.width == 0 && display.height == 0 {
-                // We don't have the res yet, store the transform for now 
-                display.wl_transform = Some(*transform);
-                return; // Confirmed to not be done, unless your compositor's fucked
-            } else {
+            display.wl_transform = Some(*transform);
+            if display.width != 0 || display.height != 0 {
                 // Will reset wl_transform to None for us
                 display.wl_calc_transform();
-            }
+            } 
+            return; // Confirmed to not be done, unless your compositor's fucked
         }
         if let wl_output::Event::Mode { width, height, refresh, .. } = &event {
             display.width = match width.to_string().parse::<u16>() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,7 +218,7 @@ fn main() {
     }
 
     // AND displays
-    let mut displays: Option<Vec<DisplayInfo>> = None;
+    let mut displays: Option<Result<Vec<DisplayInfo>, ModuleError>> = None;
     let mut display_index: u32 = 0;
     if modules.contains(&"displays".to_string()) {
         displays = Some(displays::get_displays());
@@ -439,15 +439,25 @@ fn main() {
                     }
                 },
                 "displays" => {
-                    let displays: &Vec<DisplayInfo> = displays.as_ref().unwrap();
-                    if displays.len() > display_index as usize {
-                        let display: &DisplayInfo = displays.get(display_index as usize).unwrap();
-                        print!("{}", display.style(&config, max_title_length));
-                        display_index += 1;
-                        // once again, sketchy
-                        if displays.len() > display_index as usize {
-                            modules.insert(line_number as usize, "displays".to_string());
-                        }
+                    let displays: &Result<Vec<DisplayInfo>, ModuleError> = displays.as_ref().unwrap();
+                    match displays {
+                        Ok(displays) => {
+                            if displays.len() > display_index as usize {
+                                let display: &DisplayInfo = displays.get(display_index as usize).unwrap();
+                                print!("{}", display.style(&config, max_title_length));
+                                display_index += 1;
+                                // once again, sketchy
+                                if displays.len() > display_index as usize {
+                                    modules.insert(line_number as usize, "displays".to_string());
+                                }
+                            }
+
+                        },
+                        Err(e) => {
+                            if log_errors {
+                                print!("{}", e);
+                            }
+                        },
                     }
                 }
                 "battery" => {


### PR DESCRIPTION
During my college's final months crunch, during my downtime I finally took the time to learn how to interact with X11 and Wayland compositors. Finally, I'm using these to get accurate display info opposed to relying on EDID and other wacky stuff.
Some notes + stuff still to do;

## Wayland
Works fine from what I've tested. Todo;
- [x] Account for monitor translations (portrait monitors, etc)
- [x] Compositor Test: Hyprland
- [x] Compositor Test: Sway
- [x] Compositor Test: KDE
- [x] Compositor Test: Gnome/Mutter

## x11
Requires randr to be implemented on the compositor. 
Refresh rates do **not** work, due to x11's lack of mixed refresh rates. I've also not been able to find a place in x11rb to get the global refresh rate, nor would I accept that as it's simply going to be inaccurate.
Todo;
- [x] Compositor Test: i3
- [x] Compositor Test: KDE
- [x] Compositor Test: Gnome/Mutter