### PR TITLE
Refactor Main function

### DIFF
--- a/default-config.toml
+++ b/default-config.toml
@@ -51,7 +51,7 @@ underline_character = '―'
 segment_top = "{color-white}[======------{color-brightmagenta} {name} {color-white}------======]"
 
 # Whether to supress any errors that come or not
-suppress_errors = false
+suppress_errors = true
 
 
 [ascii]

--- a/src/battery.rs
+++ b/src/battery.rs
@@ -25,7 +25,7 @@ impl Module for BatteryInfo {
         }
     }
 
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (&config.battery.title_color).is_some() {
             title_color = &config.battery.title_color.as_ref().unwrap();
@@ -45,7 +45,32 @@ impl Module for BatteryInfo {
             seperator = config.battery.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.battery.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.battery.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.battery.title_color).is_some() {
+            title_color = config.battery.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.battery.title_bold.is_some() {
+            title_bold = config.battery.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.battery.title_italic.is_some() {
+            title_italic = config.battery.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.battery.seperator.is_some() {
+            seperator = config.battery.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.battery.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -4,7 +4,7 @@ use colored::{ColoredString, Colorize};
 use config::{builder::DefaultState, Config, ConfigBuilder};
 use serde::Deserialize;
 
-use crate::{ascii::AsciiConfiguration, cpu::CPUConfiguration, hostname::HostnameConfiguration, os::OSConfiguration};
+use crate::{ascii::AsciiConfiguration, battery::BatteryConfiguration, cpu::CPUConfiguration, desktop::DesktopConfiguration, displays::DisplayConfiguration, editor::EditorConfiguration, gpu::GPUConfiguration, host::HostConfiguration, hostname::HostnameConfiguration, locale::LocaleConfiguration, memory::MemoryConfiguration, mounts::MountConfiguration, os::OSConfiguration, packages::PackagesConfiguration, shell::ShellConfiguration, swap::SwapConfiguration, terminal::TerminalConfiguration, uptime::UptimeConfiguration};
 
 // This is a hack to get the color deserializaton working
 // Essentially it uses my own enum, and to print it you need to call color_string
@@ -120,21 +120,21 @@ pub struct Configuration {
 
     pub hostname: HostnameConfiguration,
     pub cpu: CPUConfiguration,
-    // pub gpu: GPUConfiguration,
-    // pub memory: MemoryConfiguration,
-    // pub swap: SwapConfiguration,
-    // pub mounts: MountConfiguration,
-    // pub host: HostConfiguration,
-    // pub displays: DisplayConfiguration,
+    pub gpu: GPUConfiguration,
+    pub memory: MemoryConfiguration,
+    pub swap: SwapConfiguration,
+    pub mounts: MountConfiguration,
+    pub host: HostConfiguration,
+    pub displays: DisplayConfiguration,
     pub os: OSConfiguration,
-    // pub packages: PackagesConfiguration,
-    // pub desktop: DesktopConfiguration,
-    // pub terminal: TerminalConfiguration,
-    // pub shell: ShellConfiguration,
-    // pub uptime: UptimeConfiguration,
-    // pub battery: BatteryConfiguration,
-    // pub locale: LocaleConfiguration,
-    // pub editor: EditorConfiguration
+    pub packages: PackagesConfiguration,
+    pub desktop: DesktopConfiguration,
+    pub terminal: TerminalConfiguration,
+    pub shell: ShellConfiguration,
+    pub uptime: UptimeConfiguration,
+    pub battery: BatteryConfiguration,
+    pub locale: LocaleConfiguration,
+    pub editor: EditorConfiguration
 }
 
 pub fn parse(location_override: &Option<String>, module_override: &Option<String>, ignore_file: &bool) -> Configuration {

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -4,7 +4,7 @@ use colored::{ColoredString, Colorize};
 use config::{builder::DefaultState, Config, ConfigBuilder};
 use serde::Deserialize;
 
-use crate::{ascii::AsciiConfiguration, battery::BatteryConfiguration, cpu::CPUConfiguration, desktop::DesktopConfiguration, displays::DisplayConfiguration, editor::EditorConfiguration, gpu::GPUConfiguration, host::HostConfiguration, hostname::HostnameConfiguration, locale::LocaleConfiguration, memory::MemoryConfiguration, mounts::MountConfiguration, os::OSConfiguration, packages::PackagesConfiguration, shell::ShellConfiguration, swap::SwapConfiguration, terminal::TerminalConfiguration, uptime::UptimeConfiguration};
+use crate::{ascii::AsciiConfiguration, cpu::CPUConfiguration, os::OSConfiguration};
 
 // This is a hack to get the color deserializaton working
 // Essentially it uses my own enum, and to print it you need to call color_string
@@ -118,23 +118,23 @@ pub struct Configuration {
 
     pub ascii: AsciiConfiguration,
 
-    pub hostname: HostnameConfiguration,
+    // pub hostname: HostnameConfiguration,
     pub cpu: CPUConfiguration,
-    pub gpu: GPUConfiguration,
-    pub memory: MemoryConfiguration,
-    pub swap: SwapConfiguration,
-    pub mounts: MountConfiguration,
-    pub host: HostConfiguration,
-    pub displays: DisplayConfiguration,
+    // pub gpu: GPUConfiguration,
+    // pub memory: MemoryConfiguration,
+    // pub swap: SwapConfiguration,
+    // pub mounts: MountConfiguration,
+    // pub host: HostConfiguration,
+    // pub displays: DisplayConfiguration,
     pub os: OSConfiguration,
-    pub packages: PackagesConfiguration,
-    pub desktop: DesktopConfiguration,
-    pub terminal: TerminalConfiguration,
-    pub shell: ShellConfiguration,
-    pub uptime: UptimeConfiguration,
-    pub battery: BatteryConfiguration,
-    pub locale: LocaleConfiguration,
-    pub editor: EditorConfiguration
+    // pub packages: PackagesConfiguration,
+    // pub desktop: DesktopConfiguration,
+    // pub terminal: TerminalConfiguration,
+    // pub shell: ShellConfiguration,
+    // pub uptime: UptimeConfiguration,
+    // pub battery: BatteryConfiguration,
+    // pub locale: LocaleConfiguration,
+    // pub editor: EditorConfiguration
 }
 
 pub fn parse(location_override: &Option<String>, module_override: &Option<String>, ignore_file: &bool) -> Configuration {
@@ -214,7 +214,7 @@ pub fn parse(location_override: &Option<String>, module_override: &Option<String
     builder = builder.set_default("inline_values", false).unwrap();
     builder = builder.set_default("underline_character", "―").unwrap();
     builder = builder.set_default("segment_top", "{color-white}[======------{color-brightmagenta} {name} {color-white}------======]").unwrap();
-    builder = builder.set_default("suppress_errors", false).unwrap();
+    builder = builder.set_default("suppress_errors", true).unwrap();
 
     // ASCII
     builder = builder.set_default("ascii.display", true).unwrap();
@@ -444,7 +444,7 @@ underline_character = '-'
 segment_top = "{color-white}[======------{color-brightmagenta} {name} {color-white}------======]"
 
 # Whether to supress any errors that come or not
-suppress_errors = false
+suppress_errors = true
 
 
 [ascii]

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -4,7 +4,7 @@ use colored::{ColoredString, Colorize};
 use config::{builder::DefaultState, Config, ConfigBuilder};
 use serde::Deserialize;
 
-use crate::{ascii::AsciiConfiguration, cpu::CPUConfiguration, os::OSConfiguration};
+use crate::{ascii::AsciiConfiguration, cpu::CPUConfiguration, hostname::HostnameConfiguration, os::OSConfiguration};
 
 // This is a hack to get the color deserializaton working
 // Essentially it uses my own enum, and to print it you need to call color_string
@@ -118,7 +118,7 @@ pub struct Configuration {
 
     pub ascii: AsciiConfiguration,
 
-    // pub hostname: HostnameConfiguration,
+    pub hostname: HostnameConfiguration,
     pub cpu: CPUConfiguration,
     // pub gpu: GPUConfiguration,
     // pub memory: MemoryConfiguration,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -54,7 +54,32 @@ impl Module for CPUInfo {
             seperator = config.cpu.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_size, &config.cpu.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.cpu.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.cpu.title_color).is_some() {
+            title_color = config.cpu.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.cpu.title_bold.is_some() {
+            title_bold = config.cpu.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.cpu.title_italic.is_some() {
+            title_italic = config.cpu.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.cpu.seperator.is_some() {
+            seperator = config.cpu.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.cpu.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -25,7 +25,7 @@ impl Module for DesktopInfo {
         }
     }
 
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (&config.desktop.title_color).is_some() {
             title_color = &config.desktop.title_color.as_ref().unwrap();
@@ -45,7 +45,32 @@ impl Module for DesktopInfo {
             seperator = config.desktop.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.desktop.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.desktop.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.desktop.title_color).is_some() {
+            title_color = config.desktop.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.desktop.title_bold.is_some() {
+            title_bold = config.desktop.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.desktop.title_italic.is_some() {
+            title_italic = config.desktop.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.desktop.seperator.is_some() {
+            seperator = config.desktop.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.desktop.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/displays.rs
+++ b/src/displays.rs
@@ -105,7 +105,35 @@ impl Module for DisplayInfo {
         let mut title: String = config.displays.title.clone();
         title = title.replace("{name}", &self.name);
 
-        self.default_style(config, max_title_size, &title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.displays.title_color).is_some() {
+            title_color = config.displays.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.displays.title_bold.is_some() {
+            title_bold = config.displays.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.displays.title_italic.is_some() {
+            title_italic = config.displays.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.displays.seperator.is_some() {
+            seperator = config.displays.seperator.as_ref().unwrap();
+        }
+
+        let mut title: String = config.displays.title.clone();
+        title = title.replace("{name}", "Unknown");
+
+        Self::default_style(config, max_title_size, &title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -26,7 +26,7 @@ impl Module for EditorInfo {
         }
     }
 
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (&config.editor.title_color).is_some() {
             title_color = &config.editor.title_color.as_ref().unwrap();
@@ -46,7 +46,32 @@ impl Module for EditorInfo {
             seperator = config.editor.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.editor.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.editor.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.editor.title_color).is_some() {
+            title_color = config.editor.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.editor.title_bold.is_some() {
+            title_bold = config.editor.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.editor.title_italic.is_some() {
+            title_italic = config.editor.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.editor.seperator.is_some() {
+            seperator = config.editor.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.editor.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -45,7 +45,7 @@ impl Module for GPUInfo {
         }
     }
 
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (config.gpu.title_color).is_some() {
             title_color = config.gpu.title_color.as_ref().unwrap();
@@ -65,7 +65,33 @@ impl Module for GPUInfo {
             seperator = config.gpu.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.gpu.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.gpu.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.gpu.title_color).is_some() {
+            title_color = config.gpu.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.gpu.title_bold.is_some() {
+            title_bold = config.gpu.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.gpu.title_italic.is_some() {
+            title_italic = config.gpu.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.gpu.seperator.is_some() {
+            seperator = config.gpu.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.gpu.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/host.rs
+++ b/src/host.rs
@@ -24,7 +24,7 @@ impl Module for HostInfo {
         }
     }
 
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (&config.host.title_color).is_some() {
             title_color = &config.host.title_color.as_ref().unwrap();
@@ -44,7 +44,32 @@ impl Module for HostInfo {
             seperator = config.host.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.host.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.host.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.host.title_color).is_some() {
+            title_color = config.host.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.host.title_bold.is_some() {
+            title_bold = config.host.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.host.title_italic.is_some() {
+            title_italic = config.host.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.host.seperator.is_some() {
+            seperator = config.host.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.host.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/hostname.rs
+++ b/src/hostname.rs
@@ -25,7 +25,7 @@ impl Module for HostnameInfo {
             hostname: "".to_string(),
         }
     }
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (config.hostname.title_color).is_some() {
             title_color = config.hostname.title_color.as_ref().unwrap();
@@ -45,8 +45,34 @@ impl Module for HostnameInfo {
             seperator = config.hostname.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.hostname.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.hostname.title, title_color, title_bold, title_italic, &seperator, &value)
     }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.hostname.title_color).is_some() {
+            title_color = config.hostname.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.hostname.title_bold.is_some() {
+            title_bold = config.hostname.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.hostname.title_italic.is_some() {
+            title_italic = config.hostname.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.hostname.seperator.is_some() {
+            seperator = config.hostname.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.hostname.title, title_color, title_bold, title_italic, &seperator, "Unknown")
+    }
+
     fn replace_placeholders(&self, config: &Configuration) -> String {
         config.hostname.format.replace("{username}", &self.username)
             .replace("{hostname}", &self.hostname)

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -23,7 +23,7 @@ impl Module for LocaleInfo {
         }
     }
 
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (&config.locale.title_color).is_some() {
             title_color = &config.locale.title_color.as_ref().unwrap();
@@ -43,7 +43,32 @@ impl Module for LocaleInfo {
             seperator = config.locale.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.locale.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.locale.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.locale.title_color).is_some() {
+            title_color = config.locale.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.locale.title_bold.is_some() {
+            title_bold = config.locale.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.locale.title_italic.is_some() {
+            title_italic = config.locale.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.locale.seperator.is_some() {
+            seperator = config.locale.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.locale.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,12 +153,14 @@ impl Debug for ModuleError {
 // Stores all the module's outputs as we know them
 // This is to prevent us doing additional work when we don't need to, when modules need shared data
 struct ModuleOutputs {
+    hostname: Option<Result<HostnameInfo, ModuleError>>,
     cpu: Option<Result<CPUInfo, ModuleError>>,
     os: Option<Result<OSInfo, ModuleError>>
 }
 impl ModuleOutputs {
     fn new() -> Self {
         Self {
+            hostname: None,
             cpu: None,
             os: None
         }
@@ -217,7 +219,10 @@ fn main() {
                 output.push(config.underline_character.to_string().repeat(underline_length));
             },
             "hostname" => {
-                match hostname::get_hostname() {
+                if known_outputs.hostname.is_none() {
+                    known_outputs.hostname = Some(hostname::get_hostname());
+                }
+                match known_outputs.hostname.as_ref().unwrap() {
                     Ok(hostname) => {
                         output.push(hostname.style(&config, max_title_length))
                     },
@@ -231,7 +236,10 @@ fn main() {
                 };
             },
             "cpu" => {
-                match cpu::get_cpu() {
+                if known_outputs.cpu.is_none() {
+                    known_outputs.cpu = Some(cpu::get_cpu());
+                }
+                match known_outputs.cpu.as_ref().unwrap() {
                     Ok(cpu) => {
                         output.push(cpu.style(&config, max_title_length))
                     },
@@ -242,7 +250,7 @@ fn main() {
                             output.push(CPUInfo::unknown_output(&config, max_title_length));
                         }
                     },
-                };
+                }; 
             },
             _ => {
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,7 +200,7 @@ fn main() {
             if args.distro_override.is_some() {
                 ascii = ascii::get_ascii(&args.distro_override.clone().unwrap());
             } else {
-                ascii = ascii::get_ascii(&known_outputs.os.unwrap().as_ref().unwrap().distro_id);
+                ascii = ascii::get_ascii(&known_outputs.os.as_ref().unwrap().as_ref().unwrap().distro_id);
             }
         }
     }
@@ -248,6 +248,23 @@ fn main() {
                             output.push(e.to_string());
                         } else {
                             output.push(CPUInfo::unknown_output(&config, max_title_length));
+                        }
+                    },
+                }; 
+            },
+            "os" => {
+                if known_outputs.os.is_none() {
+                    known_outputs.os = Some(os::get_os());
+                }
+                match known_outputs.os.as_ref().unwrap() {
+                    Ok(os) => {
+                        output.push(os.style(&config, max_title_length))
+                    },
+                    Err(e) => {
+                        if log_errors {
+                            output.push(e.to_string());
+                        } else {
+                            output.push(OSInfo::unknown_output(&config, max_title_length));
                         }
                     },
                 }; 

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,7 +202,6 @@ fn main() {
         }
     }
 
-
     // 
     //  Detect
     //
@@ -241,20 +240,27 @@ fn main() {
     // 
     //  Display
     //
-    let ascii_split: Vec<&str> = ascii.0.split("\n").filter(|x| x.trim() != "").collect();
-    let ascii_length: usize = ascii_split.len();
-    let ascii_target_length: u16 = ascii.1 + config.ascii.margin;
+    let mut ascii_split: Vec<&str> = Vec::new();
+    let mut ascii_length: usize = 0;
+    let mut ascii_target_length: u16 = 0;
+    if config.ascii.display {
+        ascii_split = ascii.0.split("\n").filter(|x| x.trim() != "").collect();
+        ascii_length = ascii_split.len();
+        ascii_target_length = ascii.1 + config.ascii.margin;
+    }
 
     let mut current_line: usize = 0;
     for out in output {
-        // Figure out the color first
-        print!("{}", get_ascii_line(current_line, &ascii_split, &ascii_target_length, &config));
+        if config.ascii.display {
+            // Figure out the color first
+            print!("{}", get_ascii_line(current_line, &ascii_split, &ascii_target_length, &config));
+        }
 
         print!("{}", out);
         current_line += 1;
         println!();
     }
-    if current_line < ascii_length {
+    if current_line < ascii_length && config.ascii.display {
         for _ in current_line..ascii_length {
             print!("{}", get_ascii_line(current_line, &ascii_split, &ascii_target_length, &config));
             current_line += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,17 @@
 use std::{cmp::max, env, fmt::{Debug, Display}, process::exit};
 
 use config_manager::CrabFetchColor;
-use displays::DisplayInfo;
+use cpu::CPUInfo;
 use clap::{ArgAction, Parser};
 use colored::{ColoredString, Colorize};
-use mounts::MountInfo;
 use os::OSInfo;
 
-use crate::{config_manager::{color_string, Configuration}, gpu::GPUMethod};
+use crate::config_manager::Configuration;
 
 mod cpu;
-mod memory;
 mod config_manager;
 mod ascii;
-mod hostname;
 mod os;
-mod uptime;
-mod desktop;
-mod mounts;
-mod shell;
-mod swap;
-mod gpu;
-mod terminal;
-mod host;
-mod packages;
-mod displays;
-mod battery;
-mod editor;
-mod locale;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -66,28 +50,29 @@ pub struct Args {
     module_override: Option<String>
 }
 
+// Figures out the max title length for when we're using inline value display
 fn calc_max_title_length(config: &Configuration) -> u64 {
     let mut res: u64 = 0;
     // this kinda sucks
     for module in &config.modules {
         match module.as_str() {
-            "hostname" => res = max(res, config.hostname.title.len() as u64),
+            // "hostname" => res = max(res, config.hostname.title.len() as u64),
             "cpu" => res = max(res, config.cpu.title.len() as u64),
-            "gpu" => res = max(res, config.gpu.title.len() as u64),
-            "memory" => res = max(res, config.memory.title.len() as u64),
-            "swap" => res = max(res, config.swap.title.len() as u64),
-            "mounts" => res = max(res, config.mounts.title.len() as u64),
-            "host" => res = max(res, config.host.title.len() as u64),
-            "displays" => res = max(res, config.displays.title.len() as u64),
+            // "gpu" => res = max(res, config.gpu.title.len() as u64),
+            // "memory" => res = max(res, config.memory.title.len() as u64),
+            // "swap" => res = max(res, config.swap.title.len() as u64),
+            // "mounts" => res = max(res, config.mounts.title.len() as u64),
+            // "host" => res = max(res, config.host.title.len() as u64),
+            // "displays" => res = max(res, config.displays.title.len() as u64),
             "os" => res = max(res, config.os.title.len() as u64),
-            "packages" => res = max(res, config.packages.title.len() as u64),
-            "desktop" => res = max(res, config.desktop.title.len() as u64),
-            "terminal" => res = max(res, config.terminal.title.len() as u64),
-            "shell" => res = max(res, config.shell.title.len() as u64),
-            "battery" => res = max(res, config.battery.title.len() as u64),
-            "uptime" => res = max(res, config.uptime.title.len() as u64),
-            "locale" => res = max(res, config.locale.title.len() as u64),
-            "editor" => res = max(res, config.editor.title.len() as u64),
+            // "packages" => res = max(res, config.packages.title.len() as u64),
+            // "desktop" => res = max(res, config.desktop.title.len() as u64),
+            // "terminal" => res = max(res, config.terminal.title.len() as u64),
+            // "shell" => res = max(res, config.shell.title.len() as u64),
+            // "battery" => res = max(res, config.battery.title.len() as u64),
+            // "uptime" => res = max(res, config.uptime.title.len() as u64),
+            // "locale" => res = max(res, config.locale.title.len() as u64),
+            // "editor" => res = max(res, config.editor.title.len() as u64),
             _ => {}
         }
     }
@@ -98,6 +83,7 @@ fn calc_max_title_length(config: &Configuration) -> u64 {
 trait Module {
     fn new() -> Self;
     fn style(&self, config: &Configuration, max_title_length: u64) -> String;
+    fn unknown_output(config: &Configuration, max_title_length: u64) -> String;
     fn replace_placeholders(&self, config: &Configuration) -> String;
 
     // This helps the format function lol
@@ -106,7 +92,7 @@ trait Module {
         (number * power).round() / power
     }
     // TODO: Move these params into some kinda struct or some shit idk, cus it just sucks
-    fn default_style(&self, config: &Configuration, max_title_len: u64, title: &str, title_color: &CrabFetchColor, title_bold: bool, title_italic: bool, seperator: &str) -> String {
+    fn default_style(config: &Configuration, max_title_len: u64, title: &str, title_color: &CrabFetchColor, title_bold: bool, title_italic: bool, seperator: &str, value: &str) -> String {
         let mut str: String = String::new();
 
         // Title
@@ -129,9 +115,7 @@ trait Module {
             str.push_str(seperator);
         }
 
-        let mut value: String = self.replace_placeholders(config);
-        value = self.replace_color_placeholders(&value);
-        str.push_str(&value.to_string());
+        str.push_str(value);
 
         str
     }
@@ -165,12 +149,31 @@ impl Debug for ModuleError {
 }
 
 
+// Stores all the module's outputs as we know them
+// This is to prevent us doing additional work when we don't need to, when modules need shared data
+struct ModuleOutputs {
+    cpu: Option<Result<CPUInfo, ModuleError>>,
+    os: Option<Result<OSInfo, ModuleError>>
+}
+impl ModuleOutputs {
+    fn new() -> Self {
+        Self {
+            cpu: None,
+            os: None
+        }
+    }
+}
+
 fn main() {
     // Are we defo in Linux?
     if env::consts::OS != "linux" {
         println!("CrabFetch only supports Linux! If you want to go through and add support for your own OS, make a pull request :)");
         exit(-1);
     }
+
+    // 
+    //  Parse 
+    //
 
     // Get the args/config stuff out of the way
     let args: Args = Args::parse();
@@ -179,352 +182,95 @@ fn main() {
         exit(0);
     }
     let config: Configuration = config_manager::parse(&args.config, &args.module_override, &args.ignore_config_file);
-    let log_errors = !(config.suppress_errors && args.suppress_errors);
+    let log_errors: bool = !(config.suppress_errors || args.suppress_errors);
     let max_title_length: u64 = calc_max_title_length(&config);
 
-    // Since we parse the os-release file in OS anyway, this is always called to get the
-    // ascii we want.
-    let os: Result<OSInfo, ModuleError> = os::get_os();
+    // Define our module outputs, and figure out which modules need pre-calculated 
+    let mut known_outputs: ModuleOutputs = ModuleOutputs::new();
     let mut ascii: (String, u16) = (String::new(), 0);
-    if config.ascii.display && os.is_ok() {
-        if args.distro_override.is_some() {
-            ascii = ascii::get_ascii(&args.distro_override.clone().unwrap());
-        } else {
-            ascii = ascii::get_ascii(&os.as_ref().unwrap().distro_id);
-        }
-    }
-
-    let mut line_number: u8 = 0;
-    let mut ascii_line_number: u8 = 0;
-    let target_length: u16 = ascii.1 + config.ascii.margin;
-
-    let split: Vec<&str> = ascii.0.split("\n").filter(|x| x.trim() != "").collect();
-
-    // Figure out how many total lines we have
-    let mut modules = config.modules.clone();
-    let mut module_count = modules.len();
-
-    // Drives also need to be treated specially since they need to be on a seperate line
-    // So we parse them already up here too, and just increase the index each time the module is
-    // called.
-    let mut mounts: Option<Result<Vec<MountInfo>, ModuleError>> = None;
-    let mut mount_index: u32 = 0;
-    if modules.contains(&"mounts".to_string()) {
-        mounts = Some(mounts::get_mounted_drives());
-        if mounts.as_ref().unwrap().is_ok() {
-            mounts.as_mut().unwrap().as_mut().unwrap().retain(|x| !x.is_ignored(&config));
-            module_count += mounts.as_ref().unwrap().as_ref().unwrap().len() - 1;
-        }
-    }
-
-    // AND displays
-    let mut displays: Option<Result<Vec<DisplayInfo>, ModuleError>> = None;
-    let mut display_index: u32 = 0;
-    if modules.contains(&"displays".to_string()) {
-        displays = Some(displays::get_displays());
-        module_count += 1;
-    }
-
-    let line_count = max(split.len(), module_count);
-
-    for x in 0..line_count {
-        let mut line = "";
-        if split.len() > x {
-            line = split[x]
-        }
-
-        // Figure out the color first
-        let percentage: f32 = (ascii_line_number as f32 / split.len() as f32) as f32;
-        // https://stackoverflow.com/a/68457573
-        let index: u8 = (((config.ascii.colors.len() - 1) as f32) * percentage).round() as u8;
-        let colored: ColoredString = color_string(line, config.ascii.colors.get(index as usize).unwrap());
-
-        // Print the actual ASCII
-        print!("{}", colored);
-        if colored.trim().len() != 0 {
-            // We're still going
-            ascii_line_number = ascii_line_number + 1;
-        }
-        let remainder: u16 = target_length - (line.chars().collect::<Vec<char>>().len() as u16);
-        for _ in 0..remainder {
-            print!(" ");
-        }
-
-        if modules.len() > line_number as usize {
-            let module_split: Vec<&str> = modules[line_number as usize].split(":").collect();
-            let module: String = module_split[0].to_string();
-            // print!("{}", module);
-            match module.as_str() {
-                "space" => print!(""),
-                "underline" => {
-                    let underline_length: u16 = module_split[1].parse().unwrap();
-                    for _ in 0..underline_length {
-                        print!("{}", config.underline_character);
-                    }
-                }
-
-                // Segments
-                // This is very crudely done for now but I'll expand it at a later date
-                "segment" => {
-                    let segment_name: &str = module_split[1];
-                    let mut str: String = config.segment_top.replace("{name}", segment_name);
-                    str = config_manager::replace_color_placeholders(&str);
-                    print!("{}", str);
-                }
-
-                "hostname" => {
-                    match hostname::get_hostname() {
-                        Ok(hostname) => {
-                            print!("{}", hostname.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "cpu" => {
-                    match cpu::get_cpu() {
-                        Ok(cpu) => {
-                            print!("{}", cpu.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "gpu" => {
-                    let mut method: GPUMethod = config.gpu.method.clone();
-                    if args.gpu_method.is_some() {
-                        method = match args.gpu_method.clone().unwrap().as_str() {
-                            "pcisysfile" => GPUMethod::PCISysFile,
-                            "glxinfo" => GPUMethod::GLXInfo,
-                            _ => GPUMethod::PCISysFile
-                        }
-                    }
-                    let use_cache: bool = !args.ignore_cache && config.gpu.cache;
-
-                    match gpu::get_gpu(method, use_cache) {
-                        Ok(gpu) => {
-                            print!("{}", gpu.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "memory" => {
-                    match memory::get_memory() {
-                        Ok(memory) => {
-                            print!("{}", memory.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "host" => {
-                    match host::get_host() {
-                        Ok(host) => {
-                            print!("{}", host.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "swap" => {
-                    match swap::get_swap() {
-                        Ok(swap) => {
-                            print!("{}", swap.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "mounts" => {
-                    if mounts.as_ref().is_some() {
-                        let mounts = mounts.as_ref().unwrap();
-                        match mounts {
-                            Ok(ref mounts) => {
-                                if mounts.len() > mount_index as usize {
-                                    let mount: &MountInfo = mounts.get(mount_index as usize).unwrap();
-                                    print!("{}", mount.style(&config, max_title_length));
-                                    mount_index += 1;
-                                    // sketchy - this is what makes it go through them all
-                                    if mounts.len() > mount_index as usize {
-                                        modules.insert(line_number as usize, "mounts".to_string());
-                                    }
-                                }
-                            },
-                            Err(ref e) => {
-                                if log_errors {
-                                    print!("{}", e);
-                                }
-                            }
-                        }
-                    }
-                }
-                "os" => {
-                    match os {
-                        Ok(ref os) => {
-                            print!("{}", os.style(&config, max_title_length))
-                        },
-                        Err(ref e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "packages" => print!("{}", packages::get_packages().style(&config, max_title_length)),
-                "desktop" => {
-                    match desktop::get_desktop() {
-                        Ok(desktop) => {
-                            print!("{}", desktop.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "terminal" => {
-                    match terminal::get_terminal(config.terminal.chase_ssh_pts) {
-                        Ok(terminal) => {
-                            print!("{}", terminal.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "shell" => {
-                    match shell::get_shell(config.shell.show_default_shell) {
-                        Ok(shell) => {
-                            print!("{}", shell.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "uptime" => {
-                    match uptime::get_uptime() {
-                        Ok(uptime) => {
-                            print!("{}", uptime.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "displays" => {
-                    let displays: &Result<Vec<DisplayInfo>, ModuleError> = displays.as_ref().unwrap();
-                    match displays {
-                        Ok(displays) => {
-                            if displays.len() > display_index as usize {
-                                let display: &DisplayInfo = displays.get(display_index as usize).unwrap();
-                                print!("{}", display.style(&config, max_title_length));
-                                display_index += 1;
-                                // once again, sketchy
-                                if displays.len() > display_index as usize {
-                                    modules.insert(line_number as usize, "displays".to_string());
-                                }
-                            }
-
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                }
-                "battery" => {
-                    match battery::get_battery(&config.battery.path) {
-                        Ok(battery) => {
-                            print!("{}", battery.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "editor" => {
-                    match editor::get_editor() {
-                        Ok(editor) => {
-                            print!("{}", editor.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "locale" => {
-                    match locale::get_locale() {
-                        Ok(locale) => {
-                            print!("{}", locale.style(&config, max_title_length))
-                        },
-                        Err(e) => {
-                            if log_errors {
-                                print!("{}", e);
-                            }
-                        },
-                    }
-                },
-                "colors" => {
-                    let str = "   ";
-                    print!("{}", str.on_black());
-                    print!("{}", str.on_red());
-                    print!("{}", str.on_green());
-                    print!("{}", str.on_yellow());
-                    print!("{}", str.on_blue());
-                    print!("{}", str.on_magenta());
-                    print!("{}", str.on_cyan());
-                    print!("{}", str.on_white());
-                }
-                "bright_colors" => {
-                    let str = "   ";
-                    print!("{}", str.on_bright_black());
-                    print!("{}", str.on_bright_red());
-                    print!("{}", str.on_bright_green());
-                    print!("{}", str.on_bright_yellow());
-                    print!("{}", str.on_bright_blue());
-                    print!("{}", str.on_bright_magenta());
-                    print!("{}", str.on_bright_cyan());
-                    print!("{}", str.on_bright_white());
-                }
-                _ => print!("Unknown module: {}", module),
+    if config.ascii.display {
+        // OS needs done 
+        let os: Result<OSInfo, ModuleError> = os::get_os();
+        known_outputs.os = Some(os);
+        if known_outputs.os.as_ref().unwrap().is_ok() {
+            // Calculate the ASCII stuff while we're here
+            if args.distro_override.is_some() {
+                ascii = ascii::get_ascii(&args.distro_override.clone().unwrap());
+            } else {
+                ascii = ascii::get_ascii(&known_outputs.os.unwrap().as_ref().unwrap().distro_id);
             }
         }
-        line_number = line_number + 1;
+    }
 
-        if line_number != (line_count + 1) as u8 {
-            print!("\n");
+
+    // 
+    //  Detect
+    //
+    let mut output: Vec<String> = Vec::new();
+    for module in &config.modules {
+        let module_split: Vec<&str> = module.split(":").collect();
+        let module_name: &str = module_split[0];
+        match module_name {
+            "space" => output.push("".to_string()),
+            "underline" => {
+                let underline_length: usize = module_split[1].parse().unwrap();
+                output.push(config.underline_character.to_string().repeat(underline_length));
+            },
+            "cpu" => {
+                match cpu::get_cpu() {
+                    Ok(cpu) => {
+                        output.push(cpu.style(&config, max_title_length))
+                    },
+                    Err(e) => {
+                        if log_errors {
+                            output.push(e.to_string());
+                        } else {
+                            println!("'");
+                            output.push(CPUInfo::unknown_output(&config, max_title_length));
+                        }
+                    },
+                };
+            },
+            _ => {
+
+            }
+        }
+    }
+
+
+    // 
+    //  Display
+    //
+    let ascii_split: Vec<&str> = ascii.0.split("\n").filter(|x| x.trim() != "").collect();
+    let ascii_length: usize = ascii_split.len();
+    let ascii_target_length: u16 = ascii.1 + config.ascii.margin;
+    let mut current_line: usize = 0;
+    for out in output {
+        // Figure out the color first
+
+        let mut line = String::new();
+        if ascii_split.len() > current_line {
+            line = ascii_split[current_line].to_string();
+        }
+        let remainder: u16 = ascii_target_length - (line.chars().collect::<Vec<char>>().len() as u16);
+        for _ in 0..remainder {
+            line.push_str(" ");
+        }
+        print!("{}", line);
+
+        print!("{}", out);
+        current_line += 1;
+        println!();
+    }
+    if current_line < ascii_length {
+        for line in current_line..ascii_length {
+            let mut line: &str = "";
+            if ascii_split.len() > current_line {
+                line = ascii_split[current_line];
+            }
+            print!("{}", line);
+            current_line += 1;
+            println!();
         }
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -30,7 +30,7 @@ impl Module for MemoryInfo {
         }
     }
 
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (&config.memory.title_color).is_some() {
             title_color = &config.memory.title_color.as_ref().unwrap();
@@ -50,7 +50,32 @@ impl Module for MemoryInfo {
             seperator = config.memory.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.memory.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.memory.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.memory.title_color).is_some() {
+            title_color = config.memory.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.memory.title_bold.is_some() {
+            title_bold = config.memory.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.memory.title_italic.is_some() {
+            title_italic = config.memory.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.memory.seperator.is_some() {
+            seperator = config.memory.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.memory.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/mounts.rs
+++ b/src/mounts.rs
@@ -58,7 +58,36 @@ impl Module for MountInfo {
         title = title.replace("{device}", &self.device)
             .replace("{mount}", &self.mount);
 
-        self.default_style(config, max_title_size, &title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.mounts.title_color).is_some() {
+            title_color = config.mounts.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.mounts.title_bold.is_some() {
+            title_bold = config.mounts.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.mounts.title_italic.is_some() {
+            title_italic = config.mounts.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.mounts.seperator.is_some() {
+            seperator = config.mounts.seperator.as_ref().unwrap();
+        }
+
+        let mut title: String = config.mounts.title.clone();
+        title = title.replace("{device}", "Unknown")
+            .replace("{mount}", "Unknown");
+
+        Self::default_style(config, max_title_size, &title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/os.rs
+++ b/src/os.rs
@@ -55,25 +55,25 @@ impl Module for OSInfo {
     }
     fn unknown_output(config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
-        if (config.cpu.title_color).is_some() {
-            title_color = config.cpu.title_color.as_ref().unwrap();
+        if (config.os.title_color).is_some() {
+            title_color = config.os.title_color.as_ref().unwrap();
         }
 
         let mut title_bold: bool = config.title_bold;
-        if config.cpu.title_bold.is_some() {
-            title_bold = config.cpu.title_bold.unwrap();
+        if config.os.title_bold.is_some() {
+            title_bold = config.os.title_bold.unwrap();
         }
         let mut title_italic: bool = config.title_italic;
-        if config.cpu.title_italic.is_some() {
-            title_italic = config.cpu.title_italic.unwrap();
+        if config.os.title_italic.is_some() {
+            title_italic = config.os.title_italic.unwrap();
         }
 
         let mut seperator: &str = config.seperator.as_str();
-        if config.cpu.seperator.is_some() {
-            seperator = config.cpu.seperator.as_ref().unwrap();
+        if config.os.seperator.is_some() {
+            seperator = config.os.seperator.as_ref().unwrap();
         }
 
-        Self::default_style(config, max_title_size, &config.cpu.title, title_color, title_bold, title_italic, &seperator, "Unknown")
+        Self::default_style(config, max_title_size, &config.os.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/os.rs
+++ b/src/os.rs
@@ -48,7 +48,32 @@ impl Module for OSInfo {
             seperator = config.os.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_size, &config.os.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.os.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String {
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.cpu.title_color).is_some() {
+            title_color = config.cpu.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.cpu.title_bold.is_some() {
+            title_bold = config.cpu.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.cpu.title_italic.is_some() {
+            title_italic = config.cpu.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.cpu.seperator.is_some() {
+            seperator = config.cpu.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.cpu.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -87,6 +87,12 @@ impl Module for PackagesInfo {
     fn replace_placeholders(&self, _: &Configuration) -> String {
         unimplemented!()
     }
+
+    fn unknown_output(_config: &Configuration, _max_title_length: u64) -> String {
+        // get_packages can't fail, so this isn't implemented
+        // if it does, your fucked, and panic time ensures
+        panic!("Packages should never fail, something's wrong.");
+    }
 }
 
 pub struct ManagerInfo {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -26,7 +26,7 @@ impl Module for ShellInfo {
         }
     }
 
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (&config.shell.title_color).is_some() {
             title_color = &config.shell.title_color.as_ref().unwrap();
@@ -46,7 +46,32 @@ impl Module for ShellInfo {
             seperator = config.shell.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.shell.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.shell.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.shell.title_color).is_some() {
+            title_color = config.shell.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.shell.title_bold.is_some() {
+            title_bold = config.shell.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.shell.title_italic.is_some() {
+            title_italic = config.shell.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.shell.seperator.is_some() {
+            seperator = config.shell.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.shell.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -26,7 +26,7 @@ impl Module for SwapInfo {
         }
     }
 
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (&config.swap.title_color).is_some() {
             title_color = &config.swap.title_color.as_ref().unwrap();
@@ -46,7 +46,32 @@ impl Module for SwapInfo {
             seperator = config.swap.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.swap.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.swap.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.swap.title_color).is_some() {
+            title_color = config.swap.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.swap.title_bold.is_some() {
+            title_bold = config.swap.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.swap.title_italic.is_some() {
+            title_italic = config.swap.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.swap.seperator.is_some() {
+            seperator = config.swap.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.swap.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -24,7 +24,7 @@ impl Module for TerminalInfo {
         }
     }
 
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (&config.terminal.title_color).is_some() {
             title_color = &config.terminal.title_color.as_ref().unwrap();
@@ -44,7 +44,32 @@ impl Module for TerminalInfo {
             seperator = config.terminal.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.terminal.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.terminal.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.terminal.title_color).is_some() {
+            title_color = config.terminal.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.terminal.title_bold.is_some() {
+            title_bold = config.terminal.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.terminal.title_italic.is_some() {
+            title_italic = config.terminal.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.terminal.seperator.is_some() {
+            seperator = config.terminal.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.terminal.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {

--- a/src/uptime.rs
+++ b/src/uptime.rs
@@ -24,7 +24,7 @@ impl Module for UptimeInfo {
         }
     }
 
-    fn style(&self, config: &Configuration, max_title_length: u64) -> String {
+    fn style(&self, config: &Configuration, max_title_size: u64) -> String {
         let mut title_color: &CrabFetchColor = &config.title_color;
         if (&config.uptime.title_color).is_some() {
             title_color = &config.uptime.title_color.as_ref().unwrap();
@@ -44,7 +44,32 @@ impl Module for UptimeInfo {
             seperator = config.uptime.seperator.as_ref().unwrap();
         }
 
-        self.default_style(config, max_title_length, &config.uptime.title, title_color, title_bold, title_italic, &seperator)
+        let mut value: String = self.replace_placeholders(config);
+        value = self.replace_color_placeholders(&value);
+
+        Self::default_style(config, max_title_size, &config.uptime.title, title_color, title_bold, title_italic, &seperator, &value)
+    }
+    fn unknown_output(config: &Configuration, max_title_size: u64) -> String { 
+        let mut title_color: &CrabFetchColor = &config.title_color;
+        if (config.uptime.title_color).is_some() {
+            title_color = config.uptime.title_color.as_ref().unwrap();
+        }
+
+        let mut title_bold: bool = config.title_bold;
+        if config.uptime.title_bold.is_some() {
+            title_bold = config.uptime.title_bold.unwrap();
+        }
+        let mut title_italic: bool = config.title_italic;
+        if config.uptime.title_italic.is_some() {
+            title_italic = config.uptime.title_italic.unwrap();
+        }
+
+        let mut seperator: &str = config.seperator.as_str();
+        if config.uptime.seperator.is_some() {
+            seperator = config.uptime.seperator.as_ref().unwrap();
+        }
+
+        Self::default_style(config, max_title_size, &config.uptime.title, title_color, title_bold, title_italic, &seperator, "Unknown")
     }
 
     fn replace_placeholders(&self, config: &Configuration) -> String {


### PR DESCRIPTION
On today's episode of "Sam's undiagnosed ADHD plays up", I've reworked the Main function as it was getting a bit mixed up and messy in there.
It's now been split up into 3 stages; 
- Parse; parse the config + args, as well as some basic pre-processing of the ASCII stuff
- Detection; go through all the modules the user wants and detect em, placing the output strings into a vec
- Display; output it alongside the ASCII

This seperates the detection from the output, allowing me much more freedom to preprocess and mess with the output. Also means I don't have to do any weird pre-processing with Mounts and Displays, as they could take up multiple lines.

I've also created a ModuleOutputs struct/variable, placing any values in there instead. That way if a module needs shared data from another, or if some pre-processing happens it only needs to fetch it once.

Finally I've also used this as an excuse to improve the look of suppressed errors, simply making them read "Unknown" as not to ruin the aesthetics of the output.
![image](https://github.com/LivacoNew/CrabFetch/assets/51921257/f4e7c9bf-2203-432e-bcdb-cbdeb404e685)

Performance actually sits a few nanoseconds better than before, not one of my goals with this (I was actually expecting worse) but it's nice to see.