### PR TITLE
Version Detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,9 +274,11 @@ dependencies = [
  "colored",
  "config",
  "dbus",
+ "hex",
  "humantime",
  "libc",
  "serde",
+ "sha2",
  "shellexpand",
  "sqlite",
  "wayland-client",
@@ -435,6 +437,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,5 @@ chrono = { version = "0.4.38", features = ["alloc", "android-tzdata", "clock", "
 android_system_properties = { version = "0.1.5", optional = true }
 sqlite = { version = "0.34.0", optional = true }
 which = "6.0.1"
+sha2 = "0.10.8"
+hex = "0.4.3"

--- a/default-config.toml
+++ b/default-config.toml
@@ -301,7 +301,9 @@ title = "Terminal"
 # Placeholders;
 # {name} -> The name of the terminal, e.g kitty
 # {path} -> The path of the terminal, e.g /usr/bin/kitty
-format = "{name}"
+# {version} -> The version of the terminal
+format = "{name} {version}"
+
 # Whether to find the name of the current PTS if SSH is being used. This is a togglable option as most people probably won't care to go hunting for it.
 chase_ssh_pts = false
 
@@ -311,7 +313,8 @@ title = "Shell"
 # Placeholders;
 # {name} -> The name of the shell, e.g zsh
 # {path} -> The path of the shell, e.g /usr/bin/zsh
-format = "{name}"
+# {version} -> The version of the shell.
+format = "{name} {version}"
 
 # Whether to show your default shell, instead of your current shell.
 show_default_shell = false
@@ -324,9 +327,10 @@ title = "Uptime"
 [editor]
 title = "Editor"
 # Placeholders;
-# {name} - The name of the editor
-# {path} - The path the editor is at
-format = "{name}"
+# {name} -> The name of the editor
+# {path} -> The path the editor is at
+# {version} -> The version of the editor.
+format = "{name} {version}"
 
 # Whether to turn the name into a "fancy" variant. E.g "nvim" gets turned into "NeoVim"
 fancy = true

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -259,11 +259,11 @@ pub fn parse(location_override: &Option<String>, module_override: &Option<String
     builder = builder.set_default("desktop.format", "{desktop} ({display_type})").unwrap();
 
     builder = builder.set_default("terminal.title", "Terminal").unwrap();
-    builder = builder.set_default("terminal.format", "{name}").unwrap();
+    builder = builder.set_default("terminal.format", "{name} {version}").unwrap();
     builder = builder.set_default("terminal.chase_ssh_pts", false).unwrap();
 
     builder = builder.set_default("shell.title", "Shell").unwrap();
-    builder = builder.set_default("shell.format", "{name}").unwrap();
+    builder = builder.set_default("shell.format", "{name} {version}").unwrap();
     builder = builder.set_default("shell.show_default_shell", "false").unwrap();
 
     builder = builder.set_default("uptime.title", "Uptime").unwrap();
@@ -273,7 +273,7 @@ pub fn parse(location_override: &Option<String>, module_override: &Option<String
     builder = builder.set_default("battery.path", "BAT0").unwrap();
 
     builder = builder.set_default("editor.title", "Editor").unwrap();
-    builder = builder.set_default("editor.format", "{name}").unwrap();
+    builder = builder.set_default("editor.format", "{name} {version}").unwrap();
     builder = builder.set_default("editor.fancy", true).unwrap();
 
     builder = builder.set_default("locale.title", "Locale").unwrap();
@@ -743,7 +743,9 @@ title = "Terminal"
 # Placeholders;
 # {name} -> The name of the terminal, e.g kitty
 # {path} -> The path of the terminal, e.g /usr/bin/kitty
-format = "{name}"
+# {version} -> The version of the terminal
+format = "{name} {version}"
+
 # Whether to find the name of the current PTS if SSH is being used. This is a togglable option as most people probably won't care to go hunting for it.
 chase_ssh_pts = false
 
@@ -753,7 +755,8 @@ title = "Shell"
 # Placeholders;
 # {name} -> The name of the shell, e.g zsh
 # {path} -> The path of the shell, e.g /usr/bin/zsh
-format = "{name}"
+# {version} -> The version of the shell.
+format = "{name} {version}"
 
 # Whether to show your default shell, instead of your current shell.
 show_default_shell = false
@@ -766,9 +769,10 @@ title = "Uptime"
 [editor]
 title = "Editor"
 # Placeholders;
-# {name} - The name of the editor
-# {path} - The path the editor is at
-format = "{name}"
+# {name} -> The name of the editor
+# {path} -> The path the editor is at
+# {version} -> The version of the editor.
+format = "{name} {version}"
 
 # Whether to turn the name into a "fancy" variant. E.g "nvim" gets turned into "NeoVim"
 fancy = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod config_manager;
 mod ascii;
 mod formatter;
 mod proccess_info;
+mod versions;
 
 #[derive(Parser)]
 #[command(about, long_about = None)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -603,7 +603,7 @@ fn main() {
             "terminal" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.terminal.is_none() {
-                    known_outputs.terminal = Some(terminal::get_terminal(config.terminal.chase_ssh_pts));
+                    known_outputs.terminal = Some(terminal::get_terminal(config.terminal.chase_ssh_pts, config.terminal.format.contains("{version}")));
                 }
                 match known_outputs.terminal.as_ref().unwrap() {
                     Ok(terminal) => output.push(terminal.style(&config, max_title_length)),
@@ -620,7 +620,7 @@ fn main() {
             "shell" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.shell.is_none() {
-                    known_outputs.shell = Some(shell::get_shell(config.shell.show_default_shell));
+                    known_outputs.shell = Some(shell::get_shell(config.shell.show_default_shell, config.shell.format.contains("{version}")));
                 }
                 match known_outputs.shell.as_ref().unwrap() {
                     Ok(shell) => output.push(shell.style(&config, max_title_length)),
@@ -706,7 +706,7 @@ fn main() {
             "editor" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.editor.is_none() {
-                    known_outputs.editor = Some(editor::get_editor(config.editor.fancy));
+                    known_outputs.editor = Some(editor::get_editor(config.editor.fancy, config.editor.format.contains("{version}")));
                 }
                 match known_outputs.editor.as_ref().unwrap() {
                     Ok(editor) => output.push(editor.style(&config, max_title_length)),

--- a/src/modules/editor.rs
+++ b/src/modules/editor.rs
@@ -2,11 +2,12 @@ use std::env;
 
 use serde::Deserialize;
 
-use crate::{formatter::CrabFetchColor, config_manager::Configuration, Module, ModuleError};
+use crate::{config_manager::Configuration, formatter::CrabFetchColor, versions, Module, ModuleError};
 
 pub struct EditorInfo {
     name: String,
     path: String,
+    version: String
 }
 #[derive(Deserialize)]
 pub struct EditorConfiguration {
@@ -23,6 +24,7 @@ impl Module for EditorInfo {
         EditorInfo {
             name: "".to_string(),
             path: "".to_string(),
+            version: "".to_string()
         }
     }
 
@@ -48,6 +50,7 @@ impl Module for EditorInfo {
     fn replace_placeholders(&self, config: &Configuration) -> String {
         config.editor.format.replace("{name}", &self.name)
             .replace("{path}", &self.path)
+            .replace("{version}", &self.version)
     }
 }
 
@@ -69,6 +72,7 @@ pub fn get_editor(fancy: bool) -> Result<EditorInfo, ModuleError> {
         Err(e) => return Err(ModuleError::new("Editor", format!("Could not find 'which' for {}: {}", env_value, e)))
     };
     editor.name = editor.path.split('/').last().unwrap().to_string();
+    editor.version = versions::find_version(&editor.path, Some(&editor.name)).unwrap_or("Unknown".to_string());
 
     // Convert the name to a fancy variant
     // I don't like hardcoding like this, but otherwise the result looks dumb
@@ -83,6 +87,7 @@ pub fn get_editor(fancy: bool) -> Result<EditorInfo, ModuleError> {
             _ => editor.name
         };
     }
+
 
     Ok(editor)
 }

--- a/src/modules/editor.rs
+++ b/src/modules/editor.rs
@@ -54,7 +54,7 @@ impl Module for EditorInfo {
     }
 }
 
-pub fn get_editor(fancy: bool) -> Result<EditorInfo, ModuleError> {
+pub fn get_editor(fancy: bool, fetch_version: bool) -> Result<EditorInfo, ModuleError> {
     let mut editor: EditorInfo = EditorInfo::new();
 
     let env_value: String = match env::var("EDITOR") {
@@ -72,7 +72,9 @@ pub fn get_editor(fancy: bool) -> Result<EditorInfo, ModuleError> {
         Err(e) => return Err(ModuleError::new("Editor", format!("Could not find 'which' for {}: {}", env_value, e)))
     };
     editor.name = editor.path.split('/').last().unwrap().to_string();
-    editor.version = versions::find_version(&editor.path, Some(&editor.name)).unwrap_or("Unknown".to_string());
+    if fetch_version {
+        editor.version = versions::find_version(&editor.path, Some(&editor.name)).unwrap_or("Unknown".to_string());
+    }
 
     // Convert the name to a fancy variant
     // I don't like hardcoding like this, but otherwise the result looks dumb

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -5,11 +5,12 @@ use std::{fs::File, io::Read};
 
 use serde::Deserialize;
 
-use crate::{config_manager::Configuration, formatter::CrabFetchColor, proccess_info::ProcessInfo, Module, ModuleError};
+use crate::{config_manager::Configuration, formatter::CrabFetchColor, proccess_info::ProcessInfo, Module, ModuleError, versions};
 
 pub struct ShellInfo {
     name: String,
     path: String,
+    version: String,
 }
 #[derive(Deserialize)]
 pub struct ShellConfiguration {
@@ -26,6 +27,7 @@ impl Module for ShellInfo {
         ShellInfo {
             name: "".to_string(),
             path: "".to_string(),
+            version: "".to_string()
         }
     }
 
@@ -51,6 +53,7 @@ impl Module for ShellInfo {
     fn replace_placeholders(&self, config: &Configuration) -> String {
         config.shell.format.replace("{name}", &self.name)
             .replace("{path}", &self.path)
+            .replace("{version}", &self.version)
     }
 }
 
@@ -99,6 +102,8 @@ pub fn get_shell(show_default_shell: bool) -> Result<ShellInfo, ModuleError> {
         }
     }
 
+    shell.version = versions::find_version(&shell.shell_path, Some(&shell.shell_name)).unwrap_or("Unknown".to_string());
+
     Ok(shell)
 }
 
@@ -117,6 +122,8 @@ fn get_default_shell() -> Result<ShellInfo, ModuleError> {
         .last()
         .unwrap()
         .to_string();
+
+    shell.version = versions::find_version(&shell.shell_path, Some(&shell.shell_name)).unwrap_or("Unknown".to_string());
 
     Ok(shell)
 }

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -102,7 +102,7 @@ pub fn get_shell(show_default_shell: bool) -> Result<ShellInfo, ModuleError> {
         }
     }
 
-    shell.version = versions::find_version(&shell.shell_path, Some(&shell.shell_name)).unwrap_or("Unknown".to_string());
+    shell.version = versions::find_version(&shell.path, Some(&shell.name)).unwrap_or("Unknown".to_string());
 
     Ok(shell)
 }
@@ -123,7 +123,7 @@ fn get_default_shell() -> Result<ShellInfo, ModuleError> {
         .unwrap()
         .to_string();
 
-    shell.version = versions::find_version(&shell.shell_path, Some(&shell.shell_name)).unwrap_or("Unknown".to_string());
+    shell.version = versions::find_version(&shell.path, Some(&shell.name)).unwrap_or("Unknown".to_string());
 
     Ok(shell)
 }

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -57,7 +57,7 @@ impl Module for ShellInfo {
     }
 }
 
-pub fn get_shell(show_default_shell: bool) -> Result<ShellInfo, ModuleError> {
+pub fn get_shell(show_default_shell: bool, fetch_version: bool) -> Result<ShellInfo, ModuleError> {
     let mut shell: ShellInfo = ShellInfo::new();
 
     if show_default_shell {
@@ -102,7 +102,9 @@ pub fn get_shell(show_default_shell: bool) -> Result<ShellInfo, ModuleError> {
         }
     }
 
-    shell.version = versions::find_version(&shell.path, Some(&shell.name)).unwrap_or("Unknown".to_string());
+    if fetch_version {
+        shell.version = versions::find_version(&shell.path, Some(&shell.name)).unwrap_or("Unknown".to_string());
+    }
 
     Ok(shell)
 }

--- a/src/modules/terminal.rs
+++ b/src/modules/terminal.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
-use crate::{config_manager::Configuration, formatter::CrabFetchColor, proccess_info::ProcessInfo, Module, ModuleError};
+use crate::{config_manager::Configuration, formatter::CrabFetchColor, proccess_info::ProcessInfo, versions, Module, ModuleError};
 
 pub struct TerminalInfo {
     name: String,
@@ -144,6 +144,9 @@ pub fn get_terminal(chase_ssh_tty: bool) -> Result<TerminalInfo, ModuleError> {
         Ok(r) => r,
         Err(e) => return Err(ModuleError::new("Terminal", format!("Can't get process exe: {}", e))),
     };
+
+    let x = versions::find_version(&terminal.name, Some(&terminal.path));
+    terminal.version = x.unwrap_or("Unknown".to_string());
 
     Ok(terminal)
 }

--- a/src/modules/terminal.rs
+++ b/src/modules/terminal.rs
@@ -57,7 +57,7 @@ impl Module for TerminalInfo {
     }
 }
 
-pub fn get_terminal(chase_ssh_tty: bool) -> Result<TerminalInfo, ModuleError> {
+pub fn get_terminal(chase_ssh_tty: bool, fetch_version: bool) -> Result<TerminalInfo, ModuleError> {
     let mut terminal: TerminalInfo = TerminalInfo::new();
 
     #[cfg(feature = "android")]
@@ -145,8 +145,9 @@ pub fn get_terminal(chase_ssh_tty: bool) -> Result<TerminalInfo, ModuleError> {
         Err(e) => return Err(ModuleError::new("Terminal", format!("Can't get process exe: {}", e))),
     };
 
-    let x = versions::find_version(&terminal.path, Some(&terminal.name));
-    terminal.version = x.unwrap_or("Unknown".to_string());
+    if fetch_version {
+        terminal.version = versions::find_version(&terminal.path, Some(&terminal.name)).unwrap_or("Unknown".to_string());
+    }
 
     Ok(terminal)
 }

--- a/src/modules/terminal.rs
+++ b/src/modules/terminal.rs
@@ -145,7 +145,7 @@ pub fn get_terminal(chase_ssh_tty: bool) -> Result<TerminalInfo, ModuleError> {
         Err(e) => return Err(ModuleError::new("Terminal", format!("Can't get process exe: {}", e))),
     };
 
-    let x = versions::find_version(&terminal.name, Some(&terminal.path));
+    let x = versions::find_version(&terminal.path, Some(&terminal.name));
     terminal.version = x.unwrap_or("Unknown".to_string());
 
     Ok(terminal)

--- a/src/modules/terminal.rs
+++ b/src/modules/terminal.rs
@@ -10,6 +10,7 @@ use crate::{config_manager::Configuration, formatter::CrabFetchColor, proccess_i
 pub struct TerminalInfo {
     name: String,
     path: String,
+    version: String
 }
 #[derive(Deserialize)]
 pub struct TerminalConfiguration {
@@ -26,6 +27,7 @@ impl Module for TerminalInfo {
         TerminalInfo {
             name: "Unknown".to_string(),
             path: "Unknown".to_string(),
+            version: "Unknown".to_string(),
         }
     }
 
@@ -51,6 +53,7 @@ impl Module for TerminalInfo {
     fn replace_placeholders(&self, config: &Configuration) -> String {
         config.terminal.format.replace("{name}", &self.name)
             .replace("{path}", &self.path)
+            .replace("{version}", &self.version)
     }
 }
 
@@ -113,6 +116,7 @@ pub fn get_terminal(chase_ssh_tty: bool) -> Result<TerminalInfo, ModuleError> {
         Ok(r) => r,
         Err(e) => return Err(ModuleError::new("Terminal", format!("Can't get process name: {}", e))),
     };
+
     // Fix for gnome terminal coming out as gnome-terminal-server
     if terminal.name.trim() == "gnome-terminal-server" {
         terminal.name = "GNOME Terminal".to_string();

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,6 +1,6 @@
 // Purely handles version detection
 
-fn get_version(exe_path: &str) {
+pub fn find_version(exe_path: &str) -> String {
     // Steps;
     // If it's located in /usr/bin, go to the package manager caches and search for it
     // If not (or not found), check the known checksums 
@@ -10,6 +10,8 @@ fn get_version(exe_path: &str) {
         // Consult the package manager
 
     }
+
+    todo!()
 }
 
 fn use_package_manager(name: &str) {

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,6 +1,6 @@
 // Purely handles version detection
 
-use std::process::Command;
+use std::{fs::{read_dir, ReadDir}, process::Command};
 
 pub fn find_version(exe_path: &str, name: Option<&str>) -> Option<String> {
     // Steps;
@@ -29,7 +29,7 @@ pub fn find_version(exe_path: &str, name: Option<&str>) -> Option<String> {
 }
 
 fn use_package_manager(name: &str) -> Option<String> {
-    None
+    find_pacman_package(name)
 }
 fn match_checksum(path: &str) -> Option<String> {
     None
@@ -66,4 +66,26 @@ fn parse_command(path: &str, name: &str) -> Option<String> {
 
         _ => Some(raw.split(' ').collect::<Vec<&str>>()[1].to_string()),
     }
+}
+
+// Package Managers 
+fn find_pacman_package(name: &str) -> Option<String> {
+    let dir: ReadDir = match read_dir("/var/lib/pacman/local") {
+        Ok(r) => r,
+        Err(_) => return None,
+    };
+
+    for x in dir {
+        let d = x.unwrap();
+        if !d.metadata().unwrap().is_dir() {
+            continue;
+        }
+        if !d.file_name().to_str().unwrap().starts_with(name) {
+            continue
+        }
+
+        return Some(d.file_name().to_str().unwrap().to_string());
+    }
+
+    None
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -54,8 +54,14 @@ fn parse_command(path: &str, name: &str) -> Option<String> {
 
     // Fixes for different terminals outputs
     match name {
+        // Terminals
         "xterm" => Some(raw.split('(').collect::<Vec<&str>>()[1].split(')').next().unwrap().to_string()),
         "foot" => Some(raw.split(' ').collect::<Vec<&str>>()[2].trim().to_string()),
+        // Shells
+        "bash" => Some(raw.split(' ').collect::<Vec<&str>>()[3].split('(').next().unwrap().trim().to_string()),
+        // Editors
+        "nvim" => Some(raw.split(' ').collect::<Vec<&str>>()[1].split('\n').next().unwrap()[1..].to_string()),
+
         _ => Some(raw.split(' ').collect::<Vec<&str>>()[1].to_string()),
     }
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -37,7 +37,7 @@ fn match_checksum(path: &str) -> Option<String> {
 fn parse_command(path: &str, name: &str) -> Option<String> {
     // uhoh, expect shitty performance
     let mut command: Command = Command::new(path);
-    if name == "xterm" {
+    if name == "xterm" || name == "elvish" {
         command.arg("-version");
     } else {
         command.arg("--version");
@@ -59,6 +59,8 @@ fn parse_command(path: &str, name: &str) -> Option<String> {
         "foot" => Some(raw.split(' ').collect::<Vec<&str>>()[2].trim().to_string()),
         // Shells
         "bash" => Some(raw.split(' ').collect::<Vec<&str>>()[3].split('(').next().unwrap().trim().to_string()),
+        "fish" => Some(raw.split(' ').collect::<Vec<&str>>()[2].trim().to_string()),
+        "elvish" => Some(raw.split('+').collect::<Vec<&str>>()[0].trim().to_string()),
         // Editors
         "nvim" => Some(raw.split(' ').collect::<Vec<&str>>()[1].split('\n').next().unwrap()[1..].to_string()),
 

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -231,19 +231,23 @@ fn substitite_package_name(name: &str) -> &str {
 fn compare_hash(hash: &str) -> Option<String> {
     match hash {
         // Kitty
-        "bfc1a826895089928bd40eb09a340c6f3b6eb22d51589ca32c032761ff44843b" => Some("0.35.2".to_string()),
+        "bfc1a826895089928bd40eb09a340c6f3b6eb22d51589ca32c032761ff44843b" => Some("0.35.2".to_string()), // Arch
 
         // Alacritty
-        "da793f342a25fd9cb017154bc960d7e6a93d1d9d87a5bfdaf46738d7356fce13" => Some("0.13.2".to_string()),
+        "da793f342a25fd9cb017154bc960d7e6a93d1d9d87a5bfdaf46738d7356fce13" => Some("0.13.2".to_string()), // Arch
 
         // Foot
-        "2806412806ca7289f0f9fe1d73cd28c050f53204e46d9d5610acb0bac9f347ff" => Some("1.17.2".to_string()),
+        "2806412806ca7289f0f9fe1d73cd28c050f53204e46d9d5610acb0bac9f347ff" => Some("1.17.2".to_string()), // Arch 
 
         // Terminator
-        "8735bed0720a0f5ed8297fcf870a091199044a762dd360d439cfbb6b9871a7b1" => Some("2.1.4".to_string()),
+        "8735bed0720a0f5ed8297fcf870a091199044a762dd360d439cfbb6b9871a7b1" => Some("2.1.4".to_string()), // Arch
 
         // ZSH
-        "7ac8cc89b75b595955ec56d8e4b6047c2fc233a6a10c81a137c8417d17a9a970" => Some("5.9".to_string()),
+        "7ac8cc89b75b595955ec56d8e4b6047c2fc233a6a10c81a137c8417d17a9a970" => Some("5.9".to_string()), // Arch
+
+        // Bash
+        "c3a57cc13505b15535662f892fa73f2fd922d1de80be4fa6a4b78be8a59e69f8" => Some("5.2.26".to_string()), // Arch
+        "0936c178ac1e145ede22b277f8cb6a6ce3d1390492628ef999b941a65e51fe8e" => Some("5.2.21".to_string()), // VoidLinux live boot
 
         _ => None
     }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -55,6 +55,7 @@ fn parse_command(path: &str, name: &str) -> Option<String> {
     // Fixes for different terminals outputs
     match name {
         "xterm" => Some(raw.split('(').collect::<Vec<&str>>()[1].split(')').next().unwrap().to_string()),
+        "foot" => Some(raw.split(' ').collect::<Vec<&str>>()[2].trim().to_string()),
         _ => Some(raw.split(' ').collect::<Vec<&str>>()[1].to_string()),
     }
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -12,13 +12,13 @@ pub fn find_version(exe_path: &str, name: Option<&str>) -> Option<String> {
 
     let name: &str = name.unwrap_or(exe_path.split('/').last().unwrap());
 
-    // if exe_path.starts_with("/usr/bin") {
-    //     // Consult the package manager
-    //     let package_manager: Option<String> = use_package_manager(substitite_package_name(name));
-    //     if package_manager.is_some() {
-    //         return package_manager;
-    //     }
-    // }
+    if exe_path.starts_with("/usr/bin") {
+        // Consult the package manager
+        let package_manager: Option<String> = use_package_manager(substitite_package_name(name));
+        if package_manager.is_some() {
+            return package_manager;
+        }
+    }
 
     // Match the checksum
     let checksum: Option<String> = match_checksum(exe_path);

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,6 +1,6 @@
 // Purely handles version detection
 
-pub fn find_version(exe_path: &str) -> String {
+pub fn find_version(exe_path: &str) -> Option<String> {
     // Steps;
     // If it's located in /usr/bin, go to the package manager caches and search for it
     // If not (or not found), check the known checksums 
@@ -8,18 +8,29 @@ pub fn find_version(exe_path: &str) -> String {
 
     if exe_path.starts_with("/usr/bin") {
         // Consult the package manager
-
+        let name: &str = exe_path.split('/').last().unwrap();
+        let package_manager: Option<String> = use_package_manager(name);
+        if package_manager.is_some() {
+            return package_manager;
+        }
     }
 
-    todo!()
+    // Match the checksum
+    let checksum: Option<String> = match_checksum(exe_path);
+    if checksum.is_some() {
+        return checksum;
+    }
+    
+    // Failing the above, we run {command} --version and parse it
+    parse_command(exe_path)
 }
 
-fn use_package_manager(name: &str) {
+fn use_package_manager(name: &str) -> Option<String> {
     todo!()
 }
-fn match_checksum(path: &str) {
+fn match_checksum(path: &str) -> Option<String> {
     todo!()
 }
-fn parse_command(path: &str) {
+fn parse_command(path: &str) -> Option<String> {
     todo!()
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -12,7 +12,7 @@ pub fn find_version(exe_path: &str, name: Option<&str>) -> Option<String> {
 
     if exe_path.starts_with("/usr/bin") {
         // Consult the package manager
-        let package_manager: Option<String> = use_package_manager(name);
+        let package_manager: Option<String> = use_package_manager(substitite_package_name(name));
         if package_manager.is_some() {
             return package_manager;
         }
@@ -80,12 +80,27 @@ fn find_pacman_package(name: &str) -> Option<String> {
         if !d.metadata().unwrap().is_dir() {
             continue;
         }
-        if !d.file_name().to_str().unwrap().starts_with(name) {
-            continue
-        }
 
-        return Some(d.file_name().to_str().unwrap().to_string());
+        let file_name = d.file_name();
+        let package_split: Vec<&str> = file_name.to_str().unwrap().split('-').collect();
+        let package_name: String = package_split[0..package_split.len() - 2].join("-");
+        
+        if package_name != name {
+            continue;
+        }
+        let package_version: String = package_split[package_split.len() - 2].to_string();
+
+        return Some(package_version);
     }
 
     None
+}
+
+fn substitite_package_name(name: &str) -> &str {
+    // Substitutes a executable name for the package's name
+    // E.g turns nvim to neovim 
+    match name {
+        "nvim" => "neovim",
+        _ => name
+    }
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,0 +1,23 @@
+// Purely handles version detection
+
+fn get_version(exe_path: &str) {
+    // Steps;
+    // If it's located in /usr/bin, go to the package manager caches and search for it
+    // If not (or not found), check the known checksums 
+    // If not found either, ONLY THEN go to {command} --version parsing 
+
+    if exe_path.starts_with("/usr/bin") {
+        // Consult the package manager
+
+    }
+}
+
+fn use_package_manager(name: &str) {
+    todo!()
+}
+fn match_checksum(path: &str) {
+    todo!()
+}
+fn parse_command(path: &str) {
+    todo!()
+}

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -50,7 +50,6 @@ fn parse_command(path: &str, name: &str) -> Option<String> {
 
     // Fixes for different terminals outputs
     match name {
-        "kitty" => Some(raw.split(' ').collect::<Vec<&str>>()[1].to_string()),
-        _ => Some(raw)
+        _ => Some(raw.split(' ').collect::<Vec<&str>>()[1].to_string()),
     }
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -36,9 +36,13 @@ fn match_checksum(path: &str) -> Option<String> {
 }
 fn parse_command(path: &str, name: &str) -> Option<String> {
     // uhoh, expect shitty performance
-    let output: Vec<u8> = match Command::new(path)
-        .arg("--version")
-        .output() {
+    let mut command: Command = Command::new(path);
+    if name == "xterm" {
+        command.arg("-version");
+    } else {
+        command.arg("--version");
+    }
+    let output: Vec<u8> = match command.output() {
             Ok(r) => r.stdout,
             Err(_) => return None,
         };
@@ -50,6 +54,7 @@ fn parse_command(path: &str, name: &str) -> Option<String> {
 
     // Fixes for different terminals outputs
     match name {
+        "xterm" => Some(raw.split('(').collect::<Vec<&str>>()[1].split(')').next().unwrap().to_string()),
         _ => Some(raw.split(' ').collect::<Vec<&str>>()[1].to_string()),
     }
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,14 +1,17 @@
 // Purely handles version detection
 
-pub fn find_version(exe_path: &str) -> Option<String> {
+use std::process::Command;
+
+pub fn find_version(exe_path: &str, name: Option<&str>) -> Option<String> {
     // Steps;
     // If it's located in /usr/bin, go to the package manager caches and search for it
     // If not (or not found), check the known checksums 
     // If not found either, ONLY THEN go to {command} --version parsing 
 
+    let name: &str = name.unwrap_or(exe_path.split('/').last().unwrap());
+
     if exe_path.starts_with("/usr/bin") {
         // Consult the package manager
-        let name: &str = exe_path.split('/').last().unwrap();
         let package_manager: Option<String> = use_package_manager(name);
         if package_manager.is_some() {
             return package_manager;
@@ -22,15 +25,32 @@ pub fn find_version(exe_path: &str) -> Option<String> {
     }
     
     // Failing the above, we run {command} --version and parse it
-    parse_command(exe_path)
+    parse_command(exe_path, name)
 }
 
 fn use_package_manager(name: &str) -> Option<String> {
-    todo!()
+    None
 }
 fn match_checksum(path: &str) -> Option<String> {
-    todo!()
+    None
 }
-fn parse_command(path: &str) -> Option<String> {
-    todo!()
+fn parse_command(path: &str, name: &str) -> Option<String> {
+    // uhoh, expect shitty performance
+    let output: Vec<u8> = match Command::new(path)
+        .arg("--version")
+        .output() {
+            Ok(r) => r.stdout,
+            Err(_) => return None,
+        };
+
+    let raw: String = match String::from_utf8(output) {
+        Ok(r) => r.trim().to_string(),
+        Err(_) => return None,
+    };
+
+    // Fixes for different terminals outputs
+    match name {
+        "kitty" => Some(raw.split(' ').collect::<Vec<&str>>()[1].to_string()),
+        _ => Some(raw)
+    }
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -135,6 +135,18 @@ fn compare_hash(hash: &str) -> Option<String> {
         // Kitty
         "bfc1a826895089928bd40eb09a340c6f3b6eb22d51589ca32c032761ff44843b" => Some("0.35.2".to_string()),
 
+        // Alacritty
+        "da793f342a25fd9cb017154bc960d7e6a93d1d9d87a5bfdaf46738d7356fce13" => Some("0.13.2".to_string()),
+
+        // Foot
+        "2806412806ca7289f0f9fe1d73cd28c050f53204e46d9d5610acb0bac9f347ff" => Some("1.17.2".to_string()),
+
+        // Terminator
+        "8735bed0720a0f5ed8297fcf870a091199044a762dd360d439cfbb6b9871a7b1" => Some("2.1.4".to_string()),
+
+        // ZSH
+        "7ac8cc89b75b595955ec56d8e4b6047c2fc233a6a10c81a137c8417d17a9a970" => Some("5.9".to_string()),
+
         _ => None
     }
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -123,6 +123,13 @@ fn substitite_package_name(name: &str) -> &str {
 
 
 // Known Hashes
+// Please contribute these so I'm not mind-numbingly doing these
+// 
+// Oh, and to the nerds who want to critisize this detection method in issues; this is a last ditch
+// resort to running {program} --version, as running commands like that is likely to cause really
+// really fuckin bad performance, but if we already know the hashes, we don't even have to do that. 
+// I'm sorry if it upsets you that this isn't going to catch every package's binary with every
+// build paramater and difference.
 fn compare_hash(hash: &str) -> Option<String> {
     match hash {
         // Kitty


### PR DESCRIPTION
Adds version detection to terminal, shell and editor. Detects through the following steps;

- First will search the package manager caches for the version, will only do this if the executable is in /usr/bin
- Otherwise, will compare the checksum of the executable with a list of known checksums. This is a last ditch attempt to not have to do the most potentially performance-damaging step which is;
- Run `{executable} --version` and parse it. 

To-Do before I merge;

- [x] Check for if `{version}` is present in the format before fetching the version information, as the operation is quite intensive.
- [x] Cleanup a bit of code from my prototyping

Post-merge improvements would be;

- Moving package manager readouts to a separate method/struct that does it all in pre-detection. This is because currently for each version we need to fetch, it re-parses the entire file from the start which is really expensive for package managers such as DPKG, while also adding on the overhead from the package module.
- Adding RPM, not added yet as I wasn't able to locate where versions are stored in the raw package database

Completes #13