### PR TITLE
Prevent detection of Unessasary Info (Picky Info)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -393,7 +393,7 @@ fn main() {
             "cpu" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.cpu.is_none() {
-                    known_outputs.cpu = Some(cpu::get_cpu(config.cpu.remove_trailing_processor));
+                    known_outputs.cpu = Some(cpu::get_cpu(&config));
                 }
                 match known_outputs.cpu.as_ref().unwrap() {
                     Ok(cpu) => output.push(cpu.style(&config, max_title_length)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,7 +410,7 @@ fn main() {
             "gpu" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.gpu.is_none() {
-                    known_outputs.gpu = Some(gpu::get_gpus(config.gpu.amd_accuracy, config.gpu.ignore_disabled_gpus));
+                    known_outputs.gpu = Some(gpu::get_gpus(&config));
                 }
                 match known_outputs.gpu.as_ref().unwrap() {
                     Ok(gpus) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -673,7 +673,7 @@ fn main() {
             "player" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.player.is_none() {
-                    known_outputs.player = Some(player::get_players(&config.player.ignore));
+                    known_outputs.player = Some(player::get_players(&config));
                 }
                 match known_outputs.player.as_ref().unwrap() {
                     Ok(players) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -711,7 +711,7 @@ fn main() {
             "initsys" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.initsys.is_none() {
-                    known_outputs.initsys = Some(initsys::get_init_system(config.initsys.format.contains("{version}"), config.use_version_checksums, &package_managers));
+                    known_outputs.initsys = Some(initsys::get_init_system(&config, &package_managers));
                 }
                 match known_outputs.initsys.as_ref().unwrap() {
                     Ok(init) => output.push(init.style(&config, max_title_length)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,7 +583,7 @@ fn main() {
             "terminal" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.terminal.is_none() {
-                    known_outputs.terminal = Some(terminal::get_terminal(config.terminal.chase_ssh_pts, config.terminal.format.contains("{version}"), config.use_version_checksums, &package_managers));
+                    known_outputs.terminal = Some(terminal::get_terminal(&config, &package_managers));
                 }
                 match known_outputs.terminal.as_ref().unwrap() {
                     Ok(terminal) => output.push(terminal.style(&config, max_title_length)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -536,7 +536,7 @@ fn main() {
             "os" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.os.is_none() {
-                    known_outputs.os = Some(os::get_os());
+                    known_outputs.os = Some(os::get_os(&config));
                 }
                 match known_outputs.os.as_ref().unwrap() {
                     Ok(os) => {
@@ -859,7 +859,7 @@ fn main() {
     if config.ascii.display {
         if known_outputs.os.is_none() {
             let os_bench: Option<Instant> = benchmark_point(args.benchmark); 
-            known_outputs.os = Some(os::get_os());
+            known_outputs.os = Some(os::get_os(&config));
             print_bench_time(args.benchmark, args.benchmark_warn, "OS (for ASCII)", os_bench);
         }
         if known_outputs.os.as_ref().unwrap().is_ok() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -493,7 +493,7 @@ fn main() {
             "host" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.host.is_none() {
-                    known_outputs.host = Some(host::get_host());
+                    known_outputs.host = Some(host::get_host(&config));
                 }
                 match known_outputs.host.as_ref().unwrap() {
                     Ok(host) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,7 +376,7 @@ fn main() {
             "hostname" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.hostname.is_none() {
-                    known_outputs.hostname = Some(hostname::get_hostname());
+                    known_outputs.hostname = Some(hostname::get_hostname(&config));
                 }
                 match known_outputs.hostname.as_ref().unwrap() {
                     Ok(hostname) => output.push(hostname.style(&config, max_title_length)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -600,7 +600,7 @@ fn main() {
             "shell" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.shell.is_none() {
-                    known_outputs.shell = Some(shell::get_shell(config.shell.show_default_shell, config.shell.format.contains("{version}"), config.use_version_checksums, &package_managers));
+                    known_outputs.shell = Some(shell::get_shell(&config, &package_managers));
                 }
                 match known_outputs.shell.as_ref().unwrap() {
                     Ok(shell) => output.push(shell.style(&config, max_title_length)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -566,7 +566,7 @@ fn main() {
             "desktop" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.desktop.is_none() {
-                    known_outputs.desktop = Some(desktop::get_desktop());
+                    known_outputs.desktop = Some(desktop::get_desktop(&config));
                 }
                 match known_outputs.desktop.as_ref().unwrap() {
                     Ok(desktop) => output.push(desktop.style(&config, max_title_length)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -694,7 +694,7 @@ fn main() {
             "editor" => {
                 let bench: Option<Instant> = benchmark_point(args.benchmark); 
                 if known_outputs.editor.is_none() {
-                    known_outputs.editor = Some(editor::get_editor(config.editor.fancy, config.editor.format.contains("{version}"), config.use_version_checksums, &package_managers));
+                    known_outputs.editor = Some(editor::get_editor(&config, &package_managers));
                 }
                 match known_outputs.editor.as_ref().unwrap() {
                     Ok(editor) => output.push(editor.style(&config, max_title_length)),

--- a/src/module.rs
+++ b/src/module.rs
@@ -9,6 +9,7 @@ pub trait Module {
     fn style(&self, config: &Configuration, max_title_length: u64) -> String;
     fn unknown_output(config: &Configuration, max_title_length: u64) -> String;
     fn replace_placeholders(&self, config: &Configuration) -> String;
+    fn gen_info_flags(&self, config: &Configuration) -> u32;
 
     // TODO: Move these params into some kinda struct or some shit idk, cus it just sucks
     fn default_style(config: &Configuration, max_title_len: u64, title: &str, title_color: &CrabFetchColor, title_bold: bool, title_italic: bool, separator: &str, value: &str) -> String {

--- a/src/module.rs
+++ b/src/module.rs
@@ -9,7 +9,7 @@ pub trait Module {
     fn style(&self, config: &Configuration, max_title_length: u64) -> String;
     fn unknown_output(config: &Configuration, max_title_length: u64) -> String;
     fn replace_placeholders(&self, config: &Configuration) -> String;
-    fn gen_info_flags(&self, config: &Configuration) -> u32;
+    fn gen_info_flags(&self, format: &str) -> u32;
 
     // TODO: Move these params into some kinda struct or some shit idk, cus it just sucks
     fn default_style(config: &Configuration, max_title_len: u64, title: &str, title_color: &CrabFetchColor, title_bold: bool, title_italic: bool, separator: &str, value: &str) -> String {

--- a/src/module.rs
+++ b/src/module.rs
@@ -9,7 +9,7 @@ pub trait Module {
     fn style(&self, config: &Configuration, max_title_length: u64) -> String;
     fn unknown_output(config: &Configuration, max_title_length: u64) -> String;
     fn replace_placeholders(&self, config: &Configuration) -> String;
-    fn gen_info_flags(&self, format: &str) -> u32;
+    fn gen_info_flags(format: &str) -> u32;
 
     // TODO: Move these params into some kinda struct or some shit idk, cus it just sucks
     fn default_style(config: &Configuration, max_title_len: u64, title: &str, title_color: &CrabFetchColor, title_bold: bool, title_italic: bool, separator: &str, value: &str) -> String {

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -74,8 +74,8 @@ impl Module for BatteryInfo {
             .replace("{bar}", &bar)
     }
 
-    fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+    fn gen_info_flags(_: &str) -> u32 {
+        panic!("gen_info_flags called on battery module. This should never happen, please make a bug report!")
     }
 }
 

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -74,7 +74,7 @@ impl Module for BatteryInfo {
             .replace("{bar}", &bar)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -74,7 +74,7 @@ impl Module for BatteryInfo {
             .replace("{bar}", &bar)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -73,6 +73,10 @@ impl Module for BatteryInfo {
             .replace("{percentage}", &self.percentage.to_string())
             .replace("{bar}", &bar)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub fn get_batteries() -> Result<Vec<BatteryInfo>, ModuleError> {

--- a/src/modules/cpu.rs
+++ b/src/modules/cpu.rs
@@ -72,35 +72,35 @@ impl Module for CPUInfo {
     }
 }
 
-const CPU_INFO_MODEL_NAME: u32 = 1;
-const CPU_INFO_CORES: u32 = 2;
-const CPU_INFO_THREADS: u32 = 4;
-const CPU_INFO_CURRENT_CLOCK: u32 = 8;
-const CPU_INFO_MAX_CLOCK: u32 = 16;
-const CPU_INFO_ARCH: u32 = 32;
+const CPU_INFOFLAG_MODEL_NAME: u8 = 1;
+const CPU_INFOFLAG_CORES: u8 = 2;
+const CPU_INFOFLAG_THREADS: u8 = 4;
+const CPU_INFOFLAG_CURRENT_CLOCK: u8 = 8;
+const CPU_INFOFLAG_MAX_CLOCK: u8 = 16;
+const CPU_INFOFLAG_ARCH: u8 = 32;
 
 pub fn get_cpu(config: &Configuration) -> Result<CPUInfo, ModuleError> {
     let mut cpu: CPUInfo = CPUInfo::new();
 
     // Figure out the info we need to fetch
-    let mut info_flags: u32 = 0;
+    let mut info_flags: u8 = 0;
     if config.cpu.format.contains("{name}") {
-        info_flags += CPU_INFO_MODEL_NAME
+        info_flags += CPU_INFOFLAG_MODEL_NAME
     }
     if config.cpu.format.contains("{core_count}") {
-        info_flags += CPU_INFO_CORES
+        info_flags += CPU_INFOFLAG_CORES
     }
     if config.cpu.format.contains("{thread_count}") {
-        info_flags += CPU_INFO_THREADS
+        info_flags += CPU_INFOFLAG_THREADS
     }
     if config.cpu.format.contains("{current_clock_mhz}") || config.cpu.format.contains("{current_clock_ghz}") {
-        info_flags += CPU_INFO_CURRENT_CLOCK
+        info_flags += CPU_INFOFLAG_CURRENT_CLOCK
     }
     if config.cpu.format.contains("{max_clock_mhz}") || config.cpu.format.contains("{max_clock_ghz}") {
-        info_flags += CPU_INFO_MAX_CLOCK
+        info_flags += CPU_INFOFLAG_MAX_CLOCK
     }
     if config.cpu.format.contains("{arch}") || config.cpu.format.contains("{arch}") {
-        info_flags += CPU_INFO_ARCH
+        info_flags += CPU_INFOFLAG_ARCH
     }
 
     // This ones split into 2 as theres a lot to parse
@@ -136,7 +136,7 @@ pub fn get_cpu(config: &Configuration) -> Result<CPUInfo, ModuleError> {
     Ok(cpu)
 }
 
-fn get_basic_info(cpu: &mut CPUInfo, info_flags: u32) -> Result<(), ModuleError> {
+fn get_basic_info(cpu: &mut CPUInfo, info_flags: u8) -> Result<(), ModuleError> {
     // Starts by reading and parsing /proc/cpuinfo
     // This gives us the cpu name, cores, threads and current clock
     let file: File = match File::open("/proc/cpuinfo") {
@@ -159,22 +159,22 @@ fn get_basic_info(cpu: &mut CPUInfo, info_flags: u32) -> Result<(), ModuleError>
         }
 
         if first_entry {
-            if line.starts_with("model name") && (info_flags & CPU_INFO_MODEL_NAME > 0) {
+            if line.starts_with("model name") && (info_flags & CPU_INFOFLAG_MODEL_NAME > 0) {
                 cpu.name = line.split(": ").collect::<Vec<&str>>()[1].to_string();
             }
-            if line.starts_with("cpu cores") && (info_flags & CPU_INFO_CORES > 0) {
+            if line.starts_with("cpu cores") && (info_flags & CPU_INFOFLAG_CORES > 0) {
                 cpu.cores = match line.split(": ").collect::<Vec<&str>>()[1].parse::<u16>() {
                     Ok(r) => r,
                     Err(e) => return Err(ModuleError::new("CPU", format!("WARNING: Could not parse cpu cores: {}", e))),
                 }
             }
-            if line.starts_with("siblings") && (info_flags & CPU_INFO_THREADS > 0) {
+            if line.starts_with("siblings") && (info_flags & CPU_INFOFLAG_THREADS > 0) {
                 cpu.threads = match line.split(": ").collect::<Vec<&str>>()[1].parse::<u16>() {
                     Ok(r) => r,
                     Err(e) => return Err(ModuleError::new("CPU", format!("WARNING: Could not parse cpu threads: {}", e))),
                 }
             }
-            if line.starts_with("flags") && (info_flags & CPU_INFO_ARCH > 0) {
+            if line.starts_with("flags") && (info_flags & CPU_INFOFLAG_ARCH > 0) {
                 // https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/arch/x86/include/asm/cpufeatures.h
                 for flag in line.split(": ").collect::<Vec<&str>>()[1].split(' ') {
                     // prepare for trouble
@@ -190,7 +190,7 @@ fn get_basic_info(cpu: &mut CPUInfo, info_flags: u32) -> Result<(), ModuleError>
                 }
             }
         }
-        if line.starts_with("cpu MHz") && (info_flags & CPU_INFO_CURRENT_CLOCK > 0) {
+        if line.starts_with("cpu MHz") && (info_flags & CPU_INFOFLAG_CURRENT_CLOCK > 0) {
             cpu.current_clock_mhz += match line.split(": ").collect::<Vec<&str>>()[1].parse::<f32>() {
                 Ok(r) => r,
                 Err(e) => return Err(ModuleError::new("CPU", format!("WARNING: Could not parse current cpu frequency: {}", e))),
@@ -198,7 +198,7 @@ fn get_basic_info(cpu: &mut CPUInfo, info_flags: u32) -> Result<(), ModuleError>
             cpu_mhz_count += 1;
         }
     }
-    if cpu.cores == 0 && (info_flags & CPU_INFO_CORES > 0) {
+    if cpu.cores == 0 && (info_flags & CPU_INFOFLAG_CORES > 0) {
         cpu.cores = cores;
         // Backup to /sys/devices/system/cpu/present for threads too
         // Thanks to https://stackoverflow.com/a/30150409
@@ -236,8 +236,8 @@ fn get_basic_info(cpu: &mut CPUInfo, info_flags: u32) -> Result<(), ModuleError>
     cpu.current_clock_mhz /= cpu_mhz_count as f32;
     Ok(())
 }
-fn get_max_clock(cpu: &mut CPUInfo, info_flags: u32) -> Result<(), ModuleError> {
-    if info_flags & CPU_INFO_MAX_CLOCK == 0 {
+fn get_max_clock(cpu: &mut CPUInfo, info_flags: u8) -> Result<(), ModuleError> {
+    if info_flags & CPU_INFOFLAG_MAX_CLOCK == 0 {
         return Ok(())
     }
     // All of this is relative to /sys/devices/system/cpu/X/cpufreq

--- a/src/modules/cpu.rs
+++ b/src/modules/cpu.rs
@@ -71,7 +71,7 @@ impl Module for CPUInfo {
             .replace("{arch}", &self.arch.to_string())
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         // Figure out the info we need to fetch
         let mut info_flags: u32 = 0;
 
@@ -107,7 +107,7 @@ const CPU_INFOFLAG_ARCH: u32 = 32;
 
 pub fn get_cpu(config: &Configuration) -> Result<CPUInfo, ModuleError> {
     let mut cpu: CPUInfo = CPUInfo::new();
-    let info_flags: u32 = cpu.gen_info_flags(&config.cpu.format);
+    let info_flags: u32 = CPUInfo::gen_info_flags(&config.cpu.format);
 
     // This ones split into 2 as theres a lot to parse
     match get_basic_info(&mut cpu, info_flags) {

--- a/src/modules/cpu.rs
+++ b/src/modules/cpu.rs
@@ -76,22 +76,22 @@ impl Module for CPUInfo {
         let mut info_flags: u32 = 0;
 
         if format.contains("{name}") {
-            info_flags += CPU_INFOFLAG_MODEL_NAME
+            info_flags |= CPU_INFOFLAG_MODEL_NAME
         }
         if format.contains("{core_count}") {
-            info_flags += CPU_INFOFLAG_CORES
+            info_flags |= CPU_INFOFLAG_CORES
         }
         if format.contains("{thread_count}") {
-            info_flags += CPU_INFOFLAG_THREADS
+            info_flags |= CPU_INFOFLAG_THREADS
         }
         if format.contains("{current_clock_mhz}") || format.contains("{current_clock_ghz}") {
-            info_flags += CPU_INFOFLAG_CURRENT_CLOCK
+            info_flags |= CPU_INFOFLAG_CURRENT_CLOCK
         }
         if format.contains("{max_clock_mhz}") || format.contains("{max_clock_ghz}") {
-            info_flags += CPU_INFOFLAG_MAX_CLOCK
+            info_flags |= CPU_INFOFLAG_MAX_CLOCK
         }
         if format.contains("{arch}") || format.contains("{arch}") {
-            info_flags += CPU_INFOFLAG_ARCH
+            info_flags |= CPU_INFOFLAG_ARCH
         }
 
         info_flags

--- a/src/modules/cpu.rs
+++ b/src/modules/cpu.rs
@@ -70,6 +70,10 @@ impl Module for CPUInfo {
             .replace("{max_clock_ghz}", &formatter::round((self.max_clock_mhz / 1000.0) as f64, dec_places).to_string())
             .replace("{arch}", &self.arch.to_string())
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 const CPU_INFOFLAG_MODEL_NAME: u8 = 1;

--- a/src/modules/datetime.rs
+++ b/src/modules/datetime.rs
@@ -45,8 +45,8 @@ impl Module for DateTimeInfo {
         self.datetime.format(&config.datetime.format).to_string()
     }
 
-    fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+    fn gen_info_flags(_: &str) -> u32 {
+        panic!("gen_info_flags called on datetime module. This should never happen, please make a bug report!")
     }
 }
 

--- a/src/modules/datetime.rs
+++ b/src/modules/datetime.rs
@@ -45,7 +45,7 @@ impl Module for DateTimeInfo {
         self.datetime.format(&config.datetime.format).to_string()
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/datetime.rs
+++ b/src/modules/datetime.rs
@@ -45,7 +45,7 @@ impl Module for DateTimeInfo {
         self.datetime.format(&config.datetime.format).to_string()
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/datetime.rs
+++ b/src/modules/datetime.rs
@@ -44,6 +44,10 @@ impl Module for DateTimeInfo {
     fn replace_placeholders(&self, config: &Configuration) -> String {
         self.datetime.format(&config.datetime.format).to_string()
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub fn get_date_time() -> DateTimeInfo {

--- a/src/modules/desktop.rs
+++ b/src/modules/desktop.rs
@@ -49,7 +49,7 @@ impl Module for DesktopInfo {
             .replace("{display_type}", &self.display_type)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/desktop.rs
+++ b/src/modules/desktop.rs
@@ -49,7 +49,7 @@ impl Module for DesktopInfo {
             .replace("{display_type}", &self.display_type)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         let mut info_flags: u32 = 0;
 
         if format.contains("{desktop}") {
@@ -68,7 +68,7 @@ const DESKTOP_INFOFLAG_DISPLAY_TYPE: u32 = 2;
 
 pub fn get_desktop(config: &Configuration) -> Result<DesktopInfo, ModuleError> {
     let mut desktop: DesktopInfo = DesktopInfo::new();
-    let info_flags: u32 = desktop.gen_info_flags(&config.desktop.format);
+    let info_flags: u32 = DesktopInfo::gen_info_flags(&config.desktop.format);
 
     if is_flag_set_u32(info_flags, DESKTOP_INFOFLAG_DESKTOP) {
         desktop.desktop = match env::var("XDG_CURRENT_DESKTOP") {

--- a/src/modules/desktop.rs
+++ b/src/modules/desktop.rs
@@ -53,10 +53,10 @@ impl Module for DesktopInfo {
         let mut info_flags: u32 = 0;
 
         if format.contains("{desktop}") {
-            info_flags += DESKTOP_INFOFLAG_DESKTOP
+            info_flags |= DESKTOP_INFOFLAG_DESKTOP
         }
         if format.contains("{display_type}") {
-            info_flags += DESKTOP_INFOFLAG_DISPLAY_TYPE
+            info_flags |= DESKTOP_INFOFLAG_DISPLAY_TYPE
         }
 
         info_flags

--- a/src/modules/desktop.rs
+++ b/src/modules/desktop.rs
@@ -50,23 +50,25 @@ impl Module for DesktopInfo {
     }
 
     fn gen_info_flags(&self, format: &str) -> u32 {
-        todo!()
+        let mut info_flags: u32 = 0;
+
+        if format.contains("{desktop}") {
+            info_flags += DESKTOP_INFOFLAG_DESKTOP
+        }
+        if format.contains("{display_type}") {
+            info_flags += DESKTOP_INFOFLAG_DISPLAY_TYPE
+        }
+
+        info_flags
     }
 }
 
-const DESKTOP_INFOFLAG_DESKTOP: u8 = 1;
-const DESKTOP_INFOFLAG_DISPLAY_TYPE: u8 = 2;
+const DESKTOP_INFOFLAG_DESKTOP: u32 = 1;
+const DESKTOP_INFOFLAG_DISPLAY_TYPE: u32 = 2;
 
 pub fn get_desktop(config: &Configuration) -> Result<DesktopInfo, ModuleError> {
     let mut desktop: DesktopInfo = DesktopInfo::new();
-
-    let mut info_flags: u8 = 0;
-    if config.desktop.format.contains("{desktop}") {
-        info_flags += DESKTOP_INFOFLAG_DESKTOP
-    }
-    if config.desktop.format.contains("{display_type}") {
-        info_flags += DESKTOP_INFOFLAG_DISPLAY_TYPE
-    }
+    let info_flags: u32 = desktop.gen_info_flags(&config.desktop.format);
 
     if info_flags & DESKTOP_INFOFLAG_DESKTOP > 0 {
         desktop.desktop = match env::var("XDG_CURRENT_DESKTOP") {

--- a/src/modules/desktop.rs
+++ b/src/modules/desktop.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use serde::Deserialize;
 
-use crate::{formatter::CrabFetchColor, config_manager::Configuration, module::Module, ModuleError};
+use crate::{config_manager::Configuration, formatter::CrabFetchColor, module::Module, util::is_flag_set_u32, ModuleError};
 
 pub struct DesktopInfo {
     desktop: String,
@@ -70,14 +70,14 @@ pub fn get_desktop(config: &Configuration) -> Result<DesktopInfo, ModuleError> {
     let mut desktop: DesktopInfo = DesktopInfo::new();
     let info_flags: u32 = desktop.gen_info_flags(&config.desktop.format);
 
-    if info_flags & DESKTOP_INFOFLAG_DESKTOP > 0 {
+    if is_flag_set_u32(info_flags, DESKTOP_INFOFLAG_DESKTOP) {
         desktop.desktop = match env::var("XDG_CURRENT_DESKTOP") {
             Ok(r) => r,
             Err(e) => return Err(ModuleError::new("Desktop", format!("Could not parse $XDG_CURRENT_DESKTOP env variable: {}", e)))
         };
     }
 
-    if info_flags & DESKTOP_INFOFLAG_DISPLAY_TYPE > 0 {
+    if is_flag_set_u32(info_flags, DESKTOP_INFOFLAG_DISPLAY_TYPE) {
         desktop.display_type = match env::var("XDG_SESSION_TYPE") {
             Ok(r) => r,
             Err(_) => {

--- a/src/modules/desktop.rs
+++ b/src/modules/desktop.rs
@@ -48,6 +48,10 @@ impl Module for DesktopInfo {
         config.desktop.format.replace("{desktop}", &self.desktop)
             .replace("{display_type}", &self.display_type)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 const DESKTOP_INFOFLAG_DESKTOP: u8 = 1;

--- a/src/modules/displays.rs
+++ b/src/modules/displays.rs
@@ -128,7 +128,7 @@ impl Module for DisplayInfo {
             .replace("{refresh_rate}", &refresh_rate)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         let mut info_flags: u32 = 0;
 
         if format.contains("{name}") {
@@ -174,10 +174,8 @@ const DISPLAYS_INFOFLAG_HEIGHT: u32 = 16;
 const DISPLAYS_INFOFLAG_REFRESH_RATE: u32 = 32;
 
 pub fn get_displays(config: &Configuration) -> Result<Vec<DisplayInfo>, ModuleError> {
-    // Aint gonna lie this exists just for the info_flags call
-    let displays: DisplayInfo = DisplayInfo::new();
     // title is tagged onto the end here to account for the title placeholders
-    let info_flags: u32 = displays.gen_info_flags(&format!("{}{}", config.displays.format, config.displays.title));
+    let info_flags: u32 = DisplayInfo::gen_info_flags(&format!("{}{}", config.displays.format, config.displays.title));
 
     // Good news, during my college final deadline hell over the past 2 months, I learned how to
     // use a display server connection!

--- a/src/modules/displays.rs
+++ b/src/modules/displays.rs
@@ -468,7 +468,6 @@ fn fetch_wayland(config: &Configuration, info_flags: u32) -> Result<Vec<DisplayI
             x.scale_resolution();
         }
         
-        println!("{info_flags:#b}");
         if is_flag_set_u32(info_flags, DISPLAYS_INFOFLAG_MAKE) || is_flag_set_u32(info_flags, DISPLAYS_INFOFLAG_MODEL) {
             (x.make, x.model) = match get_edid_makemodel(&x.name) {
                 Ok(r) => r,

--- a/src/modules/displays.rs
+++ b/src/modules/displays.rs
@@ -127,6 +127,10 @@ impl Module for DisplayInfo {
             .replace("{height}", &self.height.to_string())
             .replace("{refresh_rate}", &refresh_rate)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 impl DisplayInfo {
     // Used by calc_max_title_length

--- a/src/modules/displays.rs
+++ b/src/modules/displays.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use wayland_client::{protocol::{wl_output::{self, Transform}, wl_registry}, ConnectError, Connection, Dispatch, QueueHandle, WEnum};
 use x11rb::{connection::RequestConnection, protocol::{randr::{self, MonitorInfo}, xproto::{self, ConnectionExt, CreateWindowAux, Screen, Window, WindowClass}}, COPY_DEPTH_FROM_PARENT};
 
-use crate::{formatter::CrabFetchColor, config_manager::Configuration, module::Module, ModuleError};
+use crate::{config_manager::Configuration, formatter::CrabFetchColor, module::Module, util::is_flag_set_u32, ModuleError};
 
 #[derive(Clone)]
 pub struct DisplayInfo {
@@ -129,7 +129,30 @@ impl Module for DisplayInfo {
     }
 
     fn gen_info_flags(&self, format: &str) -> u32 {
-        todo!()
+        let mut info_flags: u32 = 0;
+
+        if format.contains("{name}") {
+            info_flags |= DISPLAYS_INFOFLAG_DRM_NAME
+        }
+        if format.contains("{make}") {
+            info_flags |= DISPLAYS_INFOFLAG_MAKE;
+            info_flags |= DISPLAYS_INFOFLAG_DRM_NAME // DRM name is required for EDID
+        }
+        if format.contains("{model}") {
+            info_flags |= DISPLAYS_INFOFLAG_MODEL;
+            info_flags |= DISPLAYS_INFOFLAG_DRM_NAME // DRM name is required for EDID
+        }
+        if format.contains("{width}") {
+            info_flags |= DISPLAYS_INFOFLAG_WIDTH
+        }
+        if format.contains("{height}") {
+            info_flags |= DISPLAYS_INFOFLAG_HEIGHT
+        }
+        if format.contains("{refresh_rate}") {
+            info_flags |= DISPLAYS_INFOFLAG_REFRESH_RATE
+        }
+
+        info_flags
     }
 }
 impl DisplayInfo {
@@ -143,23 +166,35 @@ impl DisplayInfo {
     }
 }
 
+const DISPLAYS_INFOFLAG_DRM_NAME: u32 = 1;
+const DISPLAYS_INFOFLAG_MAKE: u32 = 2;
+const DISPLAYS_INFOFLAG_MODEL: u32 = 4;
+const DISPLAYS_INFOFLAG_WIDTH: u32 = 8;
+const DISPLAYS_INFOFLAG_HEIGHT: u32 = 16;
+const DISPLAYS_INFOFLAG_REFRESH_RATE: u32 = 32;
+
 pub fn get_displays(config: &Configuration) -> Result<Vec<DisplayInfo>, ModuleError> {
+    // Aint gonna lie this exists just for the info_flags call
+    let displays: DisplayInfo = DisplayInfo::new();
+    // title is tagged onto the end here to account for the title placeholders
+    let info_flags: u32 = displays.gen_info_flags(&format!("{}{}", config.displays.format, config.displays.title));
+
     // Good news, during my college final deadline hell over the past 2 months, I learned how to
     // use a display server connection!
     
     // Instead of relying on XDG_SESSION_TYPE line Desktop, I simply just check the sockets as it
     // can report any string and break if someone's dumb enough to do that
     if env::var("WAYLAND_DISPLAY").is_ok() {
-        fetch_wayland(config)
+        fetch_wayland(config, info_flags)
     } else if env::var("DISPLAY").is_ok() {
-        fetch_xorg()
+        fetch_xorg(info_flags)
     } else {
         Err(ModuleError::new("Display", "Could not identify desktop session type.".to_string()))
     }
 }
 
 
-fn fetch_xorg() -> Result<Vec<DisplayInfo>, ModuleError> {
+fn fetch_xorg(info_flags: u32) -> Result<Vec<DisplayInfo>, ModuleError> {
     // This has really opened my eyes as to why more pieces of software haven't swapped over to
     // Wayland yet, it's so much more convoluted at times compared to X11
     let (conn, screen_num) = match x11rb::connect(None) {
@@ -196,18 +231,24 @@ fn fetch_xorg() -> Result<Vec<DisplayInfo>, ModuleError> {
     let mut displays: Vec<DisplayInfo> = Vec::new();
     for monitor in monitors {
         // Get the DRM name 
-        let drm_name: String = match xproto::get_atom_name(&conn, monitor.name) {
-            Ok(r) => match r.reply() {
-                Ok(r) => String::from_utf8(r.name).unwrap(),
+        let mut drm_name: String = "Unknown".to_string();
+        if is_flag_set_u32(info_flags, DISPLAYS_INFOFLAG_DRM_NAME) {
+            drm_name = match xproto::get_atom_name(&conn, monitor.name) {
+                Ok(r) => match r.reply() {
+                    Ok(r) => String::from_utf8(r.name).unwrap(),
+                    Err(e) => return Err(ModuleError::new("Display", format!("Failed to get atomic name for monitor {}: {}", monitor.name, e))),
+                },
                 Err(e) => return Err(ModuleError::new("Display", format!("Failed to get atomic name for monitor {}: {}", monitor.name, e))),
-            },
-            Err(e) => return Err(ModuleError::new("Display", format!("Failed to get atomic name for monitor {}: {}", monitor.name, e))),
-        };
+            };
+        }
         // Find the make/model from the EDID
-        let (make, model): (String, String) = match get_edid_makemodel(&drm_name) {
-            Ok(r) => r,
-            Err(e) => return Err(ModuleError::new("Display", format!("Failed to get make/model for monitor {}: {}", monitor.name, e))),
-        };
+        let (mut make, mut model): (String, String) = ("Unknown".to_string(), "Unknown".to_string());
+        if is_flag_set_u32(info_flags, DISPLAYS_INFOFLAG_MAKE) || is_flag_set_u32(info_flags, DISPLAYS_INFOFLAG_MODEL) {
+            (make, model) = match get_edid_makemodel(&drm_name) {
+                Ok(r) => r,
+                Err(e) => return Err(ModuleError::new("Display", format!("Failed to get make/model for monitor {}: {}", monitor.name, e))),
+            };
+        }
 
         let display = DisplayInfo {
             name: drm_name,
@@ -379,7 +420,9 @@ impl Dispatch<wl_output::WlOutput, ()> for WaylandState {
         }
     }
 }
-fn fetch_wayland(config: &Configuration) -> Result<Vec<DisplayInfo>, ModuleError> {
+// NOTE: Wayland will ignore info flags, as all the events have to be passed through *regardless*
+// It will only use them for make/model with EDID, nothing else
+fn fetch_wayland(config: &Configuration, info_flags: u32) -> Result<Vec<DisplayInfo>, ModuleError> {
     let conn: Connection = match Connection::connect_to_env() {
         Ok(r) => r,
         Err(e) => {
@@ -425,10 +468,13 @@ fn fetch_wayland(config: &Configuration) -> Result<Vec<DisplayInfo>, ModuleError
             x.scale_resolution();
         }
         
-        (x.make, x.model) = match get_edid_makemodel(&x.name) {
-            Ok(r) => r,
-            Err(_) => return, // We're in a closure, can't return an error
-        };
+        println!("{info_flags:#b}");
+        if is_flag_set_u32(info_flags, DISPLAYS_INFOFLAG_MAKE) || is_flag_set_u32(info_flags, DISPLAYS_INFOFLAG_MODEL) {
+            (x.make, x.model) = match get_edid_makemodel(&x.name) {
+                Ok(r) => r,
+                Err(_) => return, // We're in a closure, can't return an error
+            };
+        }
     });
 
     displays.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));

--- a/src/modules/displays.rs
+++ b/src/modules/displays.rs
@@ -128,7 +128,7 @@ impl Module for DisplayInfo {
             .replace("{refresh_rate}", &refresh_rate)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/editor.rs
+++ b/src/modules/editor.rs
@@ -53,7 +53,7 @@ impl Module for EditorInfo {
             .replace("{version}", &self.version)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/editor.rs
+++ b/src/modules/editor.rs
@@ -64,6 +64,9 @@ impl Module for EditorInfo {
             info_flags |= EDITOR_INFOFLAG_PATH
         }
         if format.contains("{version}") {
+            // deps on all 3
+            info_flags |= EDITOR_INFOFLAG_NAME;
+            info_flags |= EDITOR_INFOFLAG_PATH;
             info_flags |= EDITOR_INFOFLAG_VERSION
         }
 

--- a/src/modules/editor.rs
+++ b/src/modules/editor.rs
@@ -52,6 +52,10 @@ impl Module for EditorInfo {
             .replace("{path}", &self.path)
             .replace("{version}", &self.version)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub fn get_editor(fancy: bool, fetch_version: bool, use_checksums: bool, package_managers: &ManagerInfo) -> Result<EditorInfo, ModuleError> {

--- a/src/modules/editor.rs
+++ b/src/modules/editor.rs
@@ -53,7 +53,7 @@ impl Module for EditorInfo {
             .replace("{version}", &self.version)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         let mut info_flags: u32 = 0;
 
         if format.contains("{name}") {
@@ -77,7 +77,7 @@ const EDITOR_INFOFLAG_VERSION: u32 = 4;
 
 pub fn get_editor(config: &Configuration, package_managers: &ManagerInfo) -> Result<EditorInfo, ModuleError> {
     let mut editor: EditorInfo = EditorInfo::new();
-    let info_flags: u32 = editor.gen_info_flags(&config.editor.format);
+    let info_flags: u32 = EditorInfo::gen_info_flags(&config.editor.format);
 
     let env_value: String = match env::var("EDITOR") {
         Ok(r) => r,

--- a/src/modules/gpu.rs
+++ b/src/modules/gpu.rs
@@ -180,6 +180,7 @@ fn fill_from_pcisysfile(gpus: &mut Vec<GPUInfo>, amd_accuracy: bool, ignore_disa
                 Err(e) => return Err(e)
             };
 
+            // TODO: Just directly search AMD, not the first pci.ids file
             gpu.vendor = device_data.0;
             if vendor_id == "1002" && amd_accuracy { // AMD
                 gpu.model = match search_amd_model(&device_id)? {

--- a/src/modules/gpu.rs
+++ b/src/modules/gpu.rs
@@ -68,6 +68,10 @@ impl Module for GPUInfo {
             .replace("{model}", &self.model)
             .replace("{vram}", &formatter::auto_format_bytes((self.vram_mb * 1000) as u64, use_ibis, 0))
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 impl GPUInfo {
     pub fn set_index(&mut self, index: u8) {

--- a/src/modules/gpu.rs
+++ b/src/modules/gpu.rs
@@ -69,7 +69,7 @@ impl Module for GPUInfo {
             .replace("{vram}", &formatter::auto_format_bytes((self.vram_mb * 1000) as u64, use_ibis, 0))
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/gpu.rs
+++ b/src/modules/gpu.rs
@@ -3,7 +3,7 @@ use std::{fs::{self, File, ReadDir}, io::{BufRead, BufReader}, path::Path};
 
 use serde::Deserialize;
 
-use crate::{config_manager::Configuration, formatter::{self, CrabFetchColor}, module::Module, util, ModuleError};
+use crate::{config_manager::Configuration, formatter::{self, CrabFetchColor}, module::Module, util::{self, is_flag_set_u32}, ModuleError};
 
 #[derive(Clone)]
 pub struct GPUInfo {
@@ -70,7 +70,22 @@ impl Module for GPUInfo {
     }
 
     fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+        let mut info_flags: u32 = 0;
+
+        // model and vendor are co-dependent
+        if format.contains("{vendor}") {
+            info_flags |= GPU_INFOFLAG_VENDOR;
+            info_flags |= GPU_INFOFLAG_MODEL;
+        }
+        if format.contains("{model}") {
+            info_flags |= GPU_INFOFLAG_MODEL;
+            info_flags |= GPU_INFOFLAG_VENDOR;
+        }
+        if format.contains("{vram}") {
+            info_flags |= GPU_INFOFLAG_VRAM
+        }
+
+        info_flags
     }
 }
 impl GPUInfo {
@@ -79,10 +94,15 @@ impl GPUInfo {
     }
 }
 
-pub fn get_gpus(amd_accuracy: bool, ignore_disabled_gpus: bool) -> Result<Vec<GPUInfo>, ModuleError> {
-    let mut gpus: Vec<GPUInfo> = Vec::new();
+const GPU_INFOFLAG_VENDOR: u32 = 1;
+const GPU_INFOFLAG_MODEL: u32 = 2;
+const GPU_INFOFLAG_VRAM: u32 = 4;
 
-    match fill_from_pcisysfile(&mut gpus, amd_accuracy, ignore_disabled_gpus) {
+pub fn get_gpus(config: &Configuration) -> Result<Vec<GPUInfo>, ModuleError> {
+    let mut gpus: Vec<GPUInfo> = Vec::new();
+    let info_flags: u32 = GPUInfo::gen_info_flags(&config.gpu.format);
+
+    match fill_from_pcisysfile(&mut gpus, config.gpu.amd_accuracy, config.gpu.ignore_disabled_gpus, info_flags) {
         Ok(_) => {},
         Err(e) => return Err(e)
     }
@@ -90,7 +110,7 @@ pub fn get_gpus(amd_accuracy: bool, ignore_disabled_gpus: bool) -> Result<Vec<GP
     Ok(gpus)
 }
 
-fn fill_from_pcisysfile(gpus: &mut Vec<GPUInfo>, amd_accuracy: bool, ignore_disabled: bool) -> Result<(), ModuleError> {
+fn fill_from_pcisysfile(gpus: &mut Vec<GPUInfo>, amd_accuracy: bool, ignore_disabled: bool, info_flags: u32) -> Result<(), ModuleError> {
     // This scans /sys/bus/pci/devices/ and checks the class to find the first display adapter it
     // can
     // This needs expanded at a later date
@@ -144,34 +164,38 @@ fn fill_from_pcisysfile(gpus: &mut Vec<GPUInfo>, amd_accuracy: bool, ignore_disa
             };
         }
 
-        // Vendor/Device
-        let vendor: String = match util::file_read(&d.path().join("vendor")) {
-            Ok(r) => r[2..].trim().to_string(),
-            Err(e) => return Err(ModuleError::new("GPU", format!("Can't read from file: {}", e))),
-        };
-        let device: String = match util::file_read(&d.path().join("device")) {
-            Ok(r) => r[2..].trim().to_string(),
-            Err(e) => return Err(ModuleError::new("GPU", format!("Can't read from file: {}", e))),
-        };
-        let device_data: (String, String) = match search_pci_ids(&vendor, &device) {
-            Ok(r) => r,
-            Err(e) => return Err(e)
-        };
-
         let mut gpu: GPUInfo = GPUInfo::new();
-        gpu.vendor = device_data.0;
-        if vendor == "1002" && amd_accuracy { // AMD
-            gpu.model = match search_amd_model(&device)? {
-                Some(r) => r,
-                None => device_data.1,
+        // Vendor/Device
+        if is_flag_set_u32(info_flags, GPU_INFOFLAG_MODEL) || is_flag_set_u32(info_flags, GPU_INFOFLAG_VENDOR) {
+            let vendor_id: String = match util::file_read(&d.path().join("vendor")) {
+                Ok(r) => r[2..].trim().to_string(),
+                Err(e) => return Err(ModuleError::new("GPU", format!("Can't read from file: {}", e))),
             };
-        } else {
-            gpu.model = device_data.1;
+            let device_id: String = match util::file_read(&d.path().join("device")) {
+                Ok(r) => r[2..].trim().to_string(),
+                Err(e) => return Err(ModuleError::new("GPU", format!("Can't read from file: {}", e))),
+            };
+            let device_data: (String, String) = match search_pci_ids(&vendor_id, &device_id) {
+                Ok(r) => r,
+                Err(e) => return Err(e)
+            };
+
+            gpu.vendor = device_data.0;
+            if vendor_id == "1002" && amd_accuracy { // AMD
+                gpu.model = match search_amd_model(&device_id)? {
+                    Some(r) => r,
+                    None => device_data.1,
+                };
+            } else {
+                gpu.model = device_data.1;
+            }
         }
 
         // Finally, Vram
-        if let Ok(r) = util::file_read(&d.path().join("mem_info_vram_total")) {
-            gpu.vram_mb = (r.trim().parse::<u64>().unwrap() / 1024 / 1024) as u32;
+        if is_flag_set_u32(info_flags, GPU_INFOFLAG_VRAM) {
+            if let Ok(r) = util::file_read(&d.path().join("mem_info_vram_total")) {
+                gpu.vram_mb = (r.trim().parse::<u64>().unwrap() / 1024 / 1024) as u32;
+            }
         }
 
         gpus.push(gpu);

--- a/src/modules/gpu.rs
+++ b/src/modules/gpu.rs
@@ -69,7 +69,7 @@ impl Module for GPUInfo {
             .replace("{vram}", &formatter::auto_format_bytes((self.vram_mb * 1000) as u64, use_ibis, 0))
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/host.rs
+++ b/src/modules/host.rs
@@ -55,7 +55,7 @@ impl Module for HostInfo {
             .replace("{chassis}", &self.chassis)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/host.rs
+++ b/src/modules/host.rs
@@ -54,6 +54,10 @@ impl Module for HostInfo {
         config.host.format.replace("{host}", &self.host)
             .replace("{chassis}", &self.chassis)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 impl HostInfo {
     // Identical to the regular style method, but placeholder's in the kernel instead

--- a/src/modules/host.rs
+++ b/src/modules/host.rs
@@ -55,7 +55,7 @@ impl Module for HostInfo {
             .replace("{chassis}", &self.chassis)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -51,7 +51,7 @@ impl Module for HostnameInfo {
             .to_string()
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -4,7 +4,7 @@ use std::{env, ffi::CStr, mem, path::Path, process::Command};
 use libc::{geteuid, getpwuid, uname};
 use serde::Deserialize;
 
-use crate::{config_manager::Configuration, formatter::CrabFetchColor, module::Module, util, ModuleError};
+use crate::{config_manager::Configuration, formatter::CrabFetchColor, module::Module, util::{self, is_flag_set_u32}, ModuleError};
 
 pub struct HostnameInfo {
     username: String,
@@ -52,54 +52,72 @@ impl Module for HostnameInfo {
     }
 
     fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+        let mut info_flags: u32 = 0;
+
+        // model and vendor are co-dependent
+        if format.contains("{hostname}") {
+            info_flags |= HOSTNAME_INFOFLAG_HOSTNAME;
+        }
+        if format.contains("{username}") {
+            info_flags |= HOSTNAME_INFOFLAG_USERNAME;
+        }
+
+        info_flags
     }
 }
 
-pub fn get_hostname() -> Result<HostnameInfo, ModuleError> {
+const HOSTNAME_INFOFLAG_HOSTNAME: u32 = 1;
+const HOSTNAME_INFOFLAG_USERNAME: u32 = 2;
+
+pub fn get_hostname(config: &Configuration) -> Result<HostnameInfo, ModuleError> {
     let mut hostname: HostnameInfo = HostnameInfo::new();
+    let info_flags: u32 = HostnameInfo::gen_info_flags(&config.hostname.format);
 
     // We'll try the safe way first, then the backup way
     // This is purely cus reading that env variable is faster
-    hostname.username = match env::var("USER") {
-        Ok(r) => r,
-        Err(_) => {
-            // syscall dangerous time
-            match get_username_unsafe() {
-                Ok(r) => r,
-                Err(_) => return Err(ModuleError::new("Hostname", "WARNING: Could not get username (env variable nor syscall)".to_string()))
+    if is_flag_set_u32(info_flags, HOSTNAME_INFOFLAG_USERNAME) {
+        hostname.username = match env::var("USER") {
+            Ok(r) => r,
+            Err(_) => {
+                // syscall dangerous time
+                match get_username_unsafe() {
+                    Ok(r) => r,
+                    Err(_) => return Err(ModuleError::new("Hostname", "WARNING: Could not get username (env variable nor syscall)".to_string()))
+                }
             }
-        }
-    };
+        };
+    }
 
 
     // Hostname
     // Unlike username, reading the hostname data as a syscall is faster than the file
-    hostname.hostname = match get_hostname_unsafe() {
-        Ok(r) => r,
-        Err(_) => {
-            let contents = match util::file_read(Path::new("/etc/hostname")) {
-                Ok(r) => r,
-                Err(_) => {
+    if is_flag_set_u32(info_flags, HOSTNAME_INFOFLAG_HOSTNAME) {
+        hostname.hostname = match get_hostname_unsafe() {
+            Ok(r) => r,
+            Err(_) => {
+                let contents = match util::file_read(Path::new("/etc/hostname")) {
+                    Ok(r) => r,
+                    Err(_) => {
+                        match backup_to_hostname_command(&mut hostname) {
+                            Ok(_) => return Ok(hostname),
+                            Err(e) => return Err(e),
+                        }
+                    },
+                };
+
+                if contents.trim().is_empty() {
                     match backup_to_hostname_command(&mut hostname) {
                         Ok(_) => return Ok(hostname),
                         Err(e) => return Err(e),
                     }
-                },
-            };
-
-            if contents.trim().is_empty() {
-                match backup_to_hostname_command(&mut hostname) {
-                    Ok(_) => return Ok(hostname),
-                    Err(e) => return Err(e),
                 }
-            }
-            contents.trim()
-                .lines()
-                .filter(|x| !x.starts_with('#'))
-                .collect()
-        },
-    };
+                contents.trim()
+                    .lines()
+                    .filter(|x| !x.starts_with('#'))
+                    .collect()
+            },
+        };
+    }
 
     Ok(hostname)
 }

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -51,7 +51,7 @@ impl Module for HostnameInfo {
             .to_string()
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -50,6 +50,10 @@ impl Module for HostnameInfo {
             .replace("{hostname}", &self.hostname)
             .to_string()
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub fn get_hostname() -> Result<HostnameInfo, ModuleError> {

--- a/src/modules/initsys.rs
+++ b/src/modules/initsys.rs
@@ -64,6 +64,9 @@ impl Module for InitSystemInfo {
             info_flags |= INITSYS_INFOFLAG_PATH
         }
         if format.contains("{version}") {
+            // deps on all 3
+            info_flags |= INITSYS_INFOFLAG_NAME;
+            info_flags |= INITSYS_INFOFLAG_PATH;
             info_flags |= INITSYS_INFOFLAG_VERSION
         }
 

--- a/src/modules/initsys.rs
+++ b/src/modules/initsys.rs
@@ -53,7 +53,7 @@ impl Module for InitSystemInfo {
             .replace("{version}", &self.version)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/initsys.rs
+++ b/src/modules/initsys.rs
@@ -53,7 +53,7 @@ impl Module for InitSystemInfo {
             .replace("{version}", &self.version)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/initsys.rs
+++ b/src/modules/initsys.rs
@@ -3,7 +3,7 @@ use std::fs;
 
 use serde::Deserialize;
 
-use crate::{config_manager::Configuration, formatter::CrabFetchColor, module::Module, package_managers::ManagerInfo, versions, ModuleError};
+use crate::{config_manager::Configuration, formatter::CrabFetchColor, module::Module, package_managers::ManagerInfo, util::is_flag_set_u32, versions, ModuleError};
 
 pub struct InitSystemInfo {
     name: String,
@@ -54,25 +54,47 @@ impl Module for InitSystemInfo {
     }
 
     fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+        let mut info_flags: u32 = 0;
+
+        if format.contains("{name}") {
+            info_flags |= INITSYS_INFOFLAG_NAME;
+            info_flags |= INITSYS_INFOFLAG_PATH // deps on path
+        }
+        if format.contains("{path}") {
+            info_flags |= INITSYS_INFOFLAG_PATH
+        }
+        if format.contains("{version}") {
+            info_flags |= INITSYS_INFOFLAG_VERSION
+        }
+
+        info_flags
     }
 }
 
-pub fn get_init_system(fetch_version: bool, use_checksums: bool, package_managers: &ManagerInfo) -> Result<InitSystemInfo, ModuleError> {
+const INITSYS_INFOFLAG_NAME: u32 = 1;
+const INITSYS_INFOFLAG_PATH: u32 = 2;
+const INITSYS_INFOFLAG_VERSION: u32 = 4;
+
+pub fn get_init_system(config: &Configuration, package_managers: &ManagerInfo) -> Result<InitSystemInfo, ModuleError> {
     let mut initsys: InitSystemInfo = InitSystemInfo::new();
+    let info_flags: u32 = InitSystemInfo::gen_info_flags(&config.initsys.format);
 
     // Just gets the symlink from /sbin/init 
-    initsys.path = match fs::canonicalize("/sbin/init") {
-        Ok(r) => r.display().to_string(),
-        Err(e) => return Err(ModuleError::new("InitSys", format!("Failed to canonicalize /sbin/init symlink: {}", e)))
-    };
-    initsys.name = initsys.path.split('/')
+    if is_flag_set_u32(info_flags, INITSYS_INFOFLAG_PATH) {
+        initsys.path = match fs::canonicalize("/sbin/init") {
+            Ok(r) => r.display().to_string(),
+            Err(e) => return Err(ModuleError::new("InitSys", format!("Failed to canonicalize /sbin/init symlink: {}", e)))
+        };
+    }
+    if is_flag_set_u32(info_flags, INITSYS_INFOFLAG_NAME) {
+        initsys.name = initsys.path.split('/')
             .last()
             .unwrap()
             .to_string();
+    }
 
-    if fetch_version {
-        initsys.version = versions::find_version(&initsys.path, Some(&initsys.name), use_checksums, package_managers).unwrap_or("Unknown".to_string());
+    if is_flag_set_u32(info_flags, INITSYS_INFOFLAG_VERSION) {
+        initsys.version = versions::find_version(&initsys.path, Some(&initsys.name), config.use_version_checksums, package_managers).unwrap_or("Unknown".to_string());
     }
 
     Ok(initsys)

--- a/src/modules/initsys.rs
+++ b/src/modules/initsys.rs
@@ -52,6 +52,10 @@ impl Module for InitSystemInfo {
             .replace("{path}", &self.path)
             .replace("{version}", &self.version)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub fn get_init_system(fetch_version: bool, use_checksums: bool, package_managers: &ManagerInfo) -> Result<InitSystemInfo, ModuleError> {

--- a/src/modules/locale.rs
+++ b/src/modules/locale.rs
@@ -48,6 +48,10 @@ impl Module for LocaleInfo {
         config.locale.format.replace("{language}", &self.language)
             .replace("{encoding}", &self.encoding)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub fn get_locale() -> Result<LocaleInfo, ModuleError> {

--- a/src/modules/locale.rs
+++ b/src/modules/locale.rs
@@ -50,11 +50,12 @@ impl Module for LocaleInfo {
     }
 
     fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+        panic!("gen_info_flags called on locale module. This should never happen, please make a bug report!")
     }
 }
 
 pub fn get_locale() -> Result<LocaleInfo, ModuleError> {
+    // no info flags here as it's all from the same source
     let mut locale: LocaleInfo = LocaleInfo::new();
 
     let raw: String = match env::var("LANG") {

--- a/src/modules/locale.rs
+++ b/src/modules/locale.rs
@@ -49,7 +49,7 @@ impl Module for LocaleInfo {
             .replace("{encoding}", &self.encoding)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/locale.rs
+++ b/src/modules/locale.rs
@@ -49,7 +49,7 @@ impl Module for LocaleInfo {
             .replace("{encoding}", &self.encoding)
     }
 
-    fn gen_info_flags(format: &str) -> u32 {
+    fn gen_info_flags(_: &str) -> u32 {
         panic!("gen_info_flags called on locale module. This should never happen, please make a bug report!")
     }
 }

--- a/src/modules/locale.rs
+++ b/src/modules/locale.rs
@@ -49,7 +49,7 @@ impl Module for LocaleInfo {
             .replace("{encoding}", &self.encoding)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/memory.rs
+++ b/src/modules/memory.rs
@@ -74,7 +74,7 @@ impl Module for MemoryInfo {
             .replace("{bar}", &bar.to_string())
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/memory.rs
+++ b/src/modules/memory.rs
@@ -74,8 +74,8 @@ impl Module for MemoryInfo {
             .replace("{bar}", &bar.to_string())
     }
 
-    fn gen_info_flags(format: &str) -> u32 {
-        panic!("gen_info_flags called on locale module. This should never happen, please make a bug report!")
+    fn gen_info_flags(_: &str) -> u32 {
+        panic!("gen_info_flags called on memory module. This should never happen, please make a bug report!")
     }
 }
 

--- a/src/modules/memory.rs
+++ b/src/modules/memory.rs
@@ -73,6 +73,10 @@ impl Module for MemoryInfo {
             .replace("{max}", &formatter::auto_format_bytes(self.max_kb, use_ibis, dec_places))
             .replace("{bar}", &bar.to_string())
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub fn get_memory() -> Result<MemoryInfo, ModuleError> {

--- a/src/modules/memory.rs
+++ b/src/modules/memory.rs
@@ -74,7 +74,7 @@ impl Module for MemoryInfo {
             .replace("{bar}", &bar.to_string())
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/memory.rs
+++ b/src/modules/memory.rs
@@ -75,11 +75,13 @@ impl Module for MemoryInfo {
     }
 
     fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+        panic!("gen_info_flags called on locale module. This should never happen, please make a bug report!")
     }
 }
 
 pub fn get_memory() -> Result<MemoryInfo, ModuleError> {
+    // no info flags here as while it would've had a slight benefit, all the info requires eachother anyway so
+    // it's hardly worth it
     let mut memory: MemoryInfo = MemoryInfo::new();
 
     // Fetches from /proc/meminfo

--- a/src/modules/mounts.rs
+++ b/src/modules/mounts.rs
@@ -100,7 +100,7 @@ impl Module for MountInfo {
             .replace("{bar}", &bar.to_string())
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/mounts.rs
+++ b/src/modules/mounts.rs
@@ -99,6 +99,10 @@ impl Module for MountInfo {
             .replace("{space_total}", &formatter::auto_format_bytes(self.space_total_kb, use_ibis, dec_places))
             .replace("{bar}", &bar.to_string())
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 impl MountInfo {
     pub fn is_ignored(&self, config: &Configuration) -> bool {

--- a/src/modules/mounts.rs
+++ b/src/modules/mounts.rs
@@ -100,7 +100,7 @@ impl Module for MountInfo {
             .replace("{bar}", &bar.to_string())
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/os.rs
+++ b/src/modules/os.rs
@@ -57,6 +57,10 @@ impl Module for OSInfo {
         config.os.format.replace("{distro}", &self.distro)
             .replace("{kernel}", &self.kernel)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 impl OSInfo {
     // Identical to the regular style method, but placeholder's in the kernel instead

--- a/src/modules/os.rs
+++ b/src/modules/os.rs
@@ -58,7 +58,7 @@ impl Module for OSInfo {
             .replace("{kernel}", &self.kernel)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/os.rs
+++ b/src/modules/os.rs
@@ -58,7 +58,7 @@ impl Module for OSInfo {
             .replace("{kernel}", &self.kernel)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/packages.rs
+++ b/src/modules/packages.rs
@@ -89,8 +89,8 @@ impl Module for PackagesInfo {
         panic!("Packages should never fail, something's wrong. Report this to my GitHub please.");
     }
 
-    fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+    fn gen_info_flags(_: &str) -> u32 {
+        panic!("gen_info_flags called on packages module. This should never happen, please make a bug report!")
     }
 }
 

--- a/src/modules/packages.rs
+++ b/src/modules/packages.rs
@@ -89,7 +89,7 @@ impl Module for PackagesInfo {
         panic!("Packages should never fail, something's wrong. Report this to my GitHub please.");
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/packages.rs
+++ b/src/modules/packages.rs
@@ -88,6 +88,10 @@ impl Module for PackagesInfo {
         // if it does, your fucked, and panic time ensures
         panic!("Packages should never fail, something's wrong. Report this to my GitHub please.");
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub struct ManagerInfo {

--- a/src/modules/packages.rs
+++ b/src/modules/packages.rs
@@ -89,7 +89,7 @@ impl Module for PackagesInfo {
         panic!("Packages should never fail, something's wrong. Report this to my GitHub please.");
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/player.rs
+++ b/src/modules/player.rs
@@ -72,7 +72,7 @@ impl Module for PlayerInfo {
             .replace("{status}", &self.status)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/player.rs
+++ b/src/modules/player.rs
@@ -71,6 +71,10 @@ impl Module for PlayerInfo {
             .replace("{player}", &self.player)
             .replace("{status}", &self.status)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub fn get_players(ignore: &Vec<String>) -> Result<Vec<PlayerInfo>, ModuleError> {

--- a/src/modules/player.rs
+++ b/src/modules/player.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use dbus::{arg, blocking::{stdintf::org_freedesktop_dbus::Properties, Connection, Proxy}};
 use serde::Deserialize;
 
-use crate::{config_manager::Configuration, formatter::CrabFetchColor, module::Module, ModuleError};
+use crate::{config_manager::Configuration, formatter::CrabFetchColor, module::Module, util::is_flag_set_u32, ModuleError};
 
 pub struct PlayerInfo {
     player: String,
@@ -73,12 +73,30 @@ impl Module for PlayerInfo {
     }
 
     fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+        let mut info_flags: u32 = 0;
+
+        if format.contains("{track}") || format.contains("{album}") || format.contains("{track_artists}") || format.contains("{album_artists}") {
+            info_flags |= PLAYER_INFOFLAG_METADATA;
+        }
+        if format.contains("{player}") {
+            info_flags |= PLAYER_INFOFLAG_PLAYER;
+        }
+        if format.contains("{status}") {
+            info_flags |= PLAYER_INFOFLAG_STATUS;
+        }
+
+        info_flags
     }
 }
 
-pub fn get_players(ignore: &Vec<String>) -> Result<Vec<PlayerInfo>, ModuleError> {
+const PLAYER_INFOFLAG_METADATA: u32 = 1;
+const PLAYER_INFOFLAG_PLAYER: u32 = 2;
+const PLAYER_INFOFLAG_STATUS: u32 = 4;
+
+pub fn get_players(config: &Configuration) -> Result<Vec<PlayerInfo>, ModuleError> {
     let mut players: Vec<PlayerInfo> = Vec::new();
+    // title is tagged onto the end here to account for the title placeholders
+    let info_flags: u32 = PlayerInfo::gen_info_flags(&format!("{}{}", config.player.format, config.player.title));
 
     let conn: Connection = match Connection::new_session() {
         Ok(r) => r,
@@ -91,43 +109,60 @@ pub fn get_players(ignore: &Vec<String>) -> Result<Vec<PlayerInfo>, ModuleError>
     };
 
     for player in found_players {
-        let name: String = player.split(".").last().unwrap().to_string();
-        if ignore.contains(&name) {
+        let name: String = player.split('.').last().unwrap().to_string();
+        if config.player.ignore.contains(&name) {
             continue // ignored
         }
 
         let proxy: Proxy<'_, &Connection> = conn.with_proxy(&player, "/org/mpris/MediaPlayer2", Duration::from_secs(1));
     
-        let player_metadata: arg::PropMap = match req_player_property(&proxy, "Metadata") {
-            Ok(r) => r,
-            Err(e) => return Err(ModuleError::new("Player", format!("Unable to fetch metadata for player: {}", e)))
+        let player_metadata: Option<arg::PropMap> = if is_flag_set_u32(info_flags, PLAYER_INFOFLAG_METADATA) {
+            match req_player_property(&proxy, "Metadata") {
+                Ok(r) => Some(r),
+                Err(e) => return Err(ModuleError::new("Player", format!("Unable to fetch metadata for player: {}", e)))
+            }
+        } else {
+            None
         };
 
+        // mess
         let info: PlayerInfo = PlayerInfo {
-            player: match req_player_identity(&proxy) {
-                Ok(r) => r.to_string(),
-                Err(_) => "Unknown".to_string(),
-            },
-            album: match arg::prop_cast::<String>(&player_metadata, "xesam:album") {
-                Some(r) => r.to_string(),
-                None => "Unknown".to_string(),
-            },
-            track: match arg::prop_cast::<String>(&player_metadata, "xesam:title") {
-                Some(r) => r.to_string(),
-                None => "Unknown".to_string(),
-            },
-            track_artists: match arg::prop_cast::<Vec<String>>(&player_metadata, "xesam:artist") {
-                Some(r) => r.to_vec(),
-                None => vec!["Unknown".to_string()],
-            },
-            album_artists: match arg::prop_cast::<Vec<String>>(&player_metadata, "xesam:albumArtist") {
-                Some(r) => r.to_vec(),
-                None => vec!["Unknown".to_string()],
-            },
-            status: match req_player_property::<String>(&proxy, "PlaybackStatus") {
-                Ok(r) => r,
-                Err(_) => "Unknown".to_string(),
-            },
+            player: if is_flag_set_u32(info_flags, PLAYER_INFOFLAG_PLAYER) {
+                match req_player_identity(&proxy) {
+                    Ok(r) => r.to_string(),
+                    Err(_) => "Unknown".to_string(),
+                }
+            } else {"Unknown".to_string()},
+            album: if is_flag_set_u32(info_flags, PLAYER_INFOFLAG_METADATA) && player_metadata.is_some() {
+                match arg::prop_cast::<String>(player_metadata.as_ref().unwrap(), "xesam:album") {
+                    Some(r) => r.to_string(),
+                    None => "Unknown".to_string(),
+                }
+            } else {"Unknown".to_string()},
+            track: if is_flag_set_u32(info_flags, PLAYER_INFOFLAG_METADATA) && player_metadata.is_some() {
+                match arg::prop_cast::<String>(player_metadata.as_ref().unwrap(), "xesam:title") {
+                    Some(r) => r.to_string(),
+                    None => "Unknown".to_string(),
+                }
+            } else {"Unknown".to_string()},
+            track_artists: if is_flag_set_u32(info_flags, PLAYER_INFOFLAG_METADATA) && player_metadata.is_some() {
+                match arg::prop_cast::<Vec<String>>(player_metadata.as_ref().unwrap(), "xesam:artist") {
+                    Some(r) => r.to_vec(),
+                    None => vec!["Unknown".to_string()],
+                }
+            } else {vec!["Unknown".to_string()]},
+            album_artists: if is_flag_set_u32(info_flags, PLAYER_INFOFLAG_METADATA) && player_metadata.is_some() {
+                match arg::prop_cast::<Vec<String>>(player_metadata.as_ref().unwrap(), "xesam:albumArtist") {
+                    Some(r) => r.to_vec(),
+                    None => vec!["Unknown".to_string()],
+                }
+            } else {vec!["Unknown".to_string()]},
+            status: if is_flag_set_u32(info_flags, PLAYER_INFOFLAG_STATUS) {
+                match req_player_property::<String>(&proxy, "PlaybackStatus") {
+                    Ok(r) => r,
+                    Err(_) => "Unknown".to_string(),
+                }
+            } else {"Unknown".to_string()},
         };
         players.push(info);
     }

--- a/src/modules/player.rs
+++ b/src/modules/player.rs
@@ -72,7 +72,7 @@ impl Module for PlayerInfo {
             .replace("{status}", &self.status)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/processes.rs
+++ b/src/modules/processes.rs
@@ -47,7 +47,7 @@ impl Module for ProcessesInfo {
         format.replace("{count}", &self.count.to_string())
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/processes.rs
+++ b/src/modules/processes.rs
@@ -47,7 +47,7 @@ impl Module for ProcessesInfo {
         format.replace("{count}", &self.count.to_string())
     }
 
-    fn gen_info_flags(format: &str) -> u32 {
+    fn gen_info_flags(_: &str) -> u32 {
         panic!("gen_info_flags called on processes module. This should never happen, please make a bug report!")
     }
 }

--- a/src/modules/processes.rs
+++ b/src/modules/processes.rs
@@ -46,6 +46,10 @@ impl Module for ProcessesInfo {
         let format: String = config.processes.format.clone().unwrap_or("{count}".to_string());
         format.replace("{count}", &self.count.to_string())
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub fn get_process_count() -> Result<ProcessesInfo, ModuleError> {

--- a/src/modules/processes.rs
+++ b/src/modules/processes.rs
@@ -47,7 +47,7 @@ impl Module for ProcessesInfo {
         format.replace("{count}", &self.count.to_string())
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/processes.rs
+++ b/src/modules/processes.rs
@@ -48,7 +48,7 @@ impl Module for ProcessesInfo {
     }
 
     fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+        panic!("gen_info_flags called on processes module. This should never happen, please make a bug report!")
     }
 }
 

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -56,7 +56,7 @@ impl Module for ShellInfo {
             .replace("{version}", &self.version)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -67,6 +67,9 @@ impl Module for ShellInfo {
             info_flags |= SHELL_INFOFLAG_PATH
         }
         if format.contains("{version}") {
+            // deps on all 3
+            info_flags |= SHELL_INFOFLAG_NAME;
+            info_flags |= SHELL_INFOFLAG_PATH;
             info_flags |= SHELL_INFOFLAG_VERSION
         }
 

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -55,6 +55,10 @@ impl Module for ShellInfo {
             .replace("{path}", &self.path)
             .replace("{version}", &self.version)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 // A list of known shells, the idea being that we keep going up in parent processes until we

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -56,7 +56,7 @@ impl Module for ShellInfo {
             .replace("{version}", &self.version)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -5,7 +5,7 @@ use std::{fs::File, io::Read};
 
 use serde::Deserialize;
 
-use crate::{config_manager::Configuration, formatter::CrabFetchColor, package_managers::ManagerInfo, proccess_info::ProcessInfo, versions, module::Module, ModuleError};
+use crate::{config_manager::Configuration, formatter::CrabFetchColor, module::Module, package_managers::ManagerInfo, proccess_info::ProcessInfo, util::is_flag_set_u32, versions, ModuleError};
 
 pub struct ShellInfo {
     name: String,
@@ -57,9 +57,26 @@ impl Module for ShellInfo {
     }
 
     fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+        let mut info_flags: u32 = 0;
+
+        if format.contains("{name}") {
+            info_flags |= SHELL_INFOFLAG_NAME;
+            info_flags |= SHELL_INFOFLAG_PATH // deps on path
+        }
+        if format.contains("{path}") {
+            info_flags |= SHELL_INFOFLAG_PATH
+        }
+        if format.contains("{version}") {
+            info_flags |= SHELL_INFOFLAG_VERSION
+        }
+
+        info_flags
     }
 }
+
+const SHELL_INFOFLAG_NAME: u32 = 1;
+const SHELL_INFOFLAG_PATH: u32 = 2;
+const SHELL_INFOFLAG_VERSION: u32 = 4;
 
 // A list of known shells, the idea being that we keep going up in parent processes until we
 // encouter one
@@ -86,11 +103,12 @@ pub const KNOWN_SHELLS: &[&str] = &[
     "xonsh"
 ];
 
-pub fn get_shell(show_default_shell: bool, fetch_version: bool, use_checksums: bool, package_managers: &ManagerInfo) -> Result<ShellInfo, ModuleError> {
+pub fn get_shell(config: &Configuration, package_managers: &ManagerInfo) -> Result<ShellInfo, ModuleError> {
     let mut shell: ShellInfo = ShellInfo::new();
+    let info_flags: u32 = ShellInfo::gen_info_flags(&config.shell.format);
 
-    if show_default_shell {
-        return get_default_shell(fetch_version, use_checksums, package_managers);
+    if config.shell.show_default_shell {
+        return get_default_shell(info_flags, config.use_version_checksums, package_managers);
     }
 
     // Goes up until we hit one of our known shells
@@ -112,8 +130,12 @@ pub fn get_shell(show_default_shell: bool, fetch_version: bool, use_checksums: b
                 Ok(r) => r,
                 Err(e) => return Err(ModuleError::new("OS", format!("Can't read from {} cmdline - {}", parent_pid, e))),
             };
-            shell.path = cmdline[1].to_string();
-            shell.name = shell.path.split('/').last().unwrap().to_string();
+            if is_flag_set_u32(info_flags, SHELL_INFOFLAG_PATH) {
+                shell.path = cmdline[1].to_string();
+            }
+            if is_flag_set_u32(info_flags, SHELL_INFOFLAG_NAME) {
+                shell.name = shell.path.split('/').last().unwrap().to_string();
+            }
         }
         #[cfg(not(feature = "android"))]
         {
@@ -138,40 +160,46 @@ pub fn get_shell(show_default_shell: bool, fetch_version: bool, use_checksums: b
     // Android already has the path/name, regular people don't tho
     #[cfg(not(feature = "android"))]
     {
-        shell.path = match parent_process.get_exe(true) {
-            Ok(r) => r,
-            Err(e) => return Err(ModuleError::new("Shell", format!("Failed to find exe path: {}", e)))
-        };
+        if is_flag_set_u32(info_flags, SHELL_INFOFLAG_PATH) {
+            shell.path = match parent_process.get_exe(true) {
+                Ok(r) => r,
+                Err(e) => return Err(ModuleError::new("Shell", format!("Failed to find exe path: {}", e)))
+            };
+        }
     }
 
-    if fetch_version {
-        shell.version = versions::find_version(&shell.path, Some(&shell.name), use_checksums, package_managers).unwrap_or("Unknown".to_string());
+    if is_flag_set_u32(info_flags, SHELL_INFOFLAG_VERSION) {
+        shell.version = versions::find_version(&shell.path, Some(&shell.name), config.use_version_checksums, package_managers).unwrap_or("Unknown".to_string());
     }
 
     Ok(shell)
 }
 
-fn get_default_shell(fetch_version: bool, use_checksums: bool, package_managers: &ManagerInfo) -> Result<ShellInfo, ModuleError> {
+fn get_default_shell(info_flags: u32, use_checksums: bool, package_managers: &ManagerInfo) -> Result<ShellInfo, ModuleError> {
     let mut shell: ShellInfo = ShellInfo::new();
 
     // This is mostly here for terminal detection, but there's a config option to use this instead
     // too :)
     // This definitely isn't the old $SHELL grabbing code, no sir.
-    shell.path = match env::var("SHELL") {
-        Ok(r) => r,
-        Err(e) => return Err(ModuleError::new("Shell", format!("Could not parse $SHELL env variable: {}", e)))
-    };
-    shell.path = match which::which(&shell.path) {
-        Ok(r) => r.display().to_string(),
-        Err(e) => return Err(ModuleError::new("Shell", format!("Could not find 'which' for {}: {}", shell.path, e)))
-    };
-    shell.name = shell.path.split('/')
-        .collect::<Vec<&str>>()
-        .last()
-        .unwrap()
-        .to_string();
+    if is_flag_set_u32(info_flags, SHELL_INFOFLAG_PATH) {
+        shell.path = match env::var("SHELL") {
+            Ok(r) => r,
+            Err(e) => return Err(ModuleError::new("Shell", format!("Could not parse $SHELL env variable: {}", e)))
+        };
+        shell.path = match which::which(&shell.path) {
+            Ok(r) => r.display().to_string(),
+            Err(e) => return Err(ModuleError::new("Shell", format!("Could not find 'which' for {}: {}", shell.path, e)))
+        };
+    }
+    if is_flag_set_u32(info_flags, SHELL_INFOFLAG_NAME) {
+        shell.name = shell.path.split('/')
+            .collect::<Vec<&str>>()
+            .last()
+            .unwrap()
+            .to_string();
+    }
 
-    if fetch_version {
+    if is_flag_set_u32(info_flags, SHELL_INFOFLAG_VERSION) {
         shell.version = versions::find_version(&shell.path, Some(&shell.name), use_checksums, package_managers).unwrap_or("Unknown".to_string());
     }
 

--- a/src/modules/swap.rs
+++ b/src/modules/swap.rs
@@ -74,13 +74,14 @@ impl Module for SwapInfo {
             .replace("{bar}", &bar)
     }
 
-    fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+    fn gen_info_flags(_: &str) -> u32 {
+        panic!("gen_info_flags called on swap module. This should never happen, please make a bug report!")
     }
 }
 
 pub fn get_swap(sysinfo: &mut Option<libc::sysinfo>) -> Result<SwapInfo, ModuleError> {
     let mut swap: SwapInfo = SwapInfo::new();
+    // no info flags here as it's all dependent on eachother
 
     let sysinfo_unwrap: libc::sysinfo = sysinfo.unwrap_or_else(|| {
         unsafe {

--- a/src/modules/swap.rs
+++ b/src/modules/swap.rs
@@ -74,7 +74,7 @@ impl Module for SwapInfo {
             .replace("{bar}", &bar)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/swap.rs
+++ b/src/modules/swap.rs
@@ -74,7 +74,7 @@ impl Module for SwapInfo {
             .replace("{bar}", &bar)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/swap.rs
+++ b/src/modules/swap.rs
@@ -73,6 +73,10 @@ impl Module for SwapInfo {
             .replace("{total}", &formatter::auto_format_bytes(self.total_kb, use_ibis, dec_places))
             .replace("{bar}", &bar)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub fn get_swap(sysinfo: &mut Option<libc::sysinfo>) -> Result<SwapInfo, ModuleError> {

--- a/src/modules/terminal.rs
+++ b/src/modules/terminal.rs
@@ -56,7 +56,7 @@ impl Module for TerminalInfo {
             .replace("{version}", &self.version)
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/terminal.rs
+++ b/src/modules/terminal.rs
@@ -56,7 +56,7 @@ impl Module for TerminalInfo {
             .replace("{version}", &self.version)
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/terminal.rs
+++ b/src/modules/terminal.rs
@@ -55,6 +55,10 @@ impl Module for TerminalInfo {
             .replace("{path}", &self.path)
             .replace("{version}", &self.version)
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 // A list of known terminals, similar to shell we keep going up until we encouter one

--- a/src/modules/uptime.rs
+++ b/src/modules/uptime.rs
@@ -48,7 +48,7 @@ impl Module for UptimeInfo {
         format.replace("{time}", &format_duration(self.uptime).to_string())
     }
 
-    fn gen_info_flags(&self, format: &str) -> u32 {
+    fn gen_info_flags(format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/modules/uptime.rs
+++ b/src/modules/uptime.rs
@@ -47,6 +47,10 @@ impl Module for UptimeInfo {
         let format: String = config.uptime.format.clone().unwrap_or("{time}".to_string());
         format.replace("{time}", &format_duration(self.uptime).to_string())
     }
+
+    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+        todo!()
+    }
 }
 
 pub fn get_uptime(sysinfo: &mut Option<libc::sysinfo>) -> Result<UptimeInfo, ModuleError> {

--- a/src/modules/uptime.rs
+++ b/src/modules/uptime.rs
@@ -48,8 +48,8 @@ impl Module for UptimeInfo {
         format.replace("{time}", &format_duration(self.uptime).to_string())
     }
 
-    fn gen_info_flags(format: &str) -> u32 {
-        todo!()
+    fn gen_info_flags(_: &str) -> u32 {
+        panic!("gen_info_flags called on uptime module. This should never happen, please make a bug report!")
     }
 }
 

--- a/src/modules/uptime.rs
+++ b/src/modules/uptime.rs
@@ -48,7 +48,7 @@ impl Module for UptimeInfo {
         format.replace("{time}", &format_duration(self.uptime).to_string())
     }
 
-    fn gen_info_flags(&self, config: &Configuration) -> u32 {
+    fn gen_info_flags(&self, format: &str) -> u32 {
         todo!()
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -44,3 +44,7 @@ pub fn find_first_pathbuf_exists(paths: Vec<PathBuf>) -> Option<PathBuf> {
 
     None
 }
+
+pub fn is_flag_set_u32(value: u32, flag: u32) -> bool {
+    value & flag > 0
+}


### PR DESCRIPTION
Today's PR I'll merge within 5 minutes adds a feature I'm coining as "picky info" (it's not actually called that anywhere in the files lol)
Essentially we only fetch what we actually *want* from the modules, depending on what placeholders are asked for. E.g don't fetch vram if `{vram}` isn't present.

The module trait now carries a `gen_info_flags(format: &str) -> u32` function that should be overridden to return a bitflag of what the module should find. Then, the module simply calls this in it's get method and checks the flags to see if it should bother parsing a particular bit of data or not. Some modules that either depend on all other bits of data, or that simply don't make sense with this system, will simply never call `gen_info_flags` and just fetch as normal.

The obvious benefit of this is performance; we're no longer fetching useless info that will never get displayed to the user. Another side benefit of this is that for `gen_info_flags` to get the format, it's let me pass in the config directly to most modules meaning less parameter counts across the board.

## Some light Performance benchmarking
`crabfetch` is commit `835c7780069fb08a7abd396b71de68956a64524f`
`./target/release/crabfetch` is on this branch, commit `25e6880b776816d71c8d827d9e16c83d8fbd7fab`
#### Default Config
![Exactly the same performance](https://i.imgur.com/0cB1zN1.png)
Mostly the same, old CrabFetch gives some better maximums but overall I'm fine with that.
I was expecting this, as the default config is essentially every piece of info it can find. This change is more-so for minimal configs that *omit* information.

#### "Minimal" Config
Here's a random config I whipped up that omits a few of the default values;
![Preview of the Test config](https://i.imgur.com/tTLq94i.png)
Most of these modules are going to have minimal (if not zero) effects. The primary pain points I'm looking for are modules like `cpu` where they're some of the heavier modules to run.

Sure enough, the results;
![1.11 times faster](https://i.imgur.com/t4zImcG.png)

Again, most modules didn't really have much of an effect, but `cpu` reduced it's runtime by roughly 150µs (I forgot to get a screenshot before deleting the config so you'll have to trust me on that one).

#### Player Module
Another module that *actually* benefits from this is the `player` module. Player identity, song metadata and player status are all separate requests. If someone doesn't care about player identity or their player's status, no point in making that next request.
![image](https://github.com/user-attachments/assets/af7e93aa-0c17-4df2-933b-c6dce945a4b7)

Using the old version, we see it takes about 500µs for it to run. Again, it's making all 3 requests in the background.
![image](https://github.com/user-attachments/assets/3c5f054f-b267-4cd2-85ac-df474494bba8)

Using this PR;
![image](https://github.com/user-attachments/assets/9460d2ce-7c1e-4a97-9bd5-a6ad24780bfc)

Hyperfine for the skeptical nerds;
![image](https://github.com/user-attachments/assets/6e15a22a-ed32-4011-af63-78ddbd75edfc)
