### PR TITLE
Fix out-of-bounds array access in `locale.rs`

### DIFF
--- a/src/modules/locale.rs
+++ b/src/modules/locale.rs
@@ -68,8 +68,8 @@ pub fn get_locale() -> Result<LocaleInfo, ModuleError> {
         Err(e) => return Err(ModuleError::new("Locale", format!("Could not parse $LANG env variable: {}", e)))
     };
     let raw_split: Vec<&str> = raw.split('.').collect();
-    locale.language = raw_split[0].to_string();
-    locale.encoding = raw_split[1].to_string();
+    locale.language = raw_split.first().unwrap_or(&locale.language.as_ref()).to_string();
+    locale.encoding = raw_split.get(1).unwrap_or(&locale.encoding.as_ref()).to_string();
 
     Ok(locale)
 }


### PR DESCRIPTION
Apologies for the unsolicited PR, figured it would be more useful than an issue.

Right now, if a user has an invalid `LANG` env var, we'll get a panic:
```
LANG=test ./target/debug/crabfetch 
thread 'main' panicked at src/modules/locale.rs:72:32:
index out of bounds: the len is 1 but the index is 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Discovered this when I tried to run `crabfetch` on a fresh PostmarketOS install that had a value of `LANG=c`.

This just uses `unwrap_or` so we fall back to `Unknown`.