### PR TITLE
Fix terminal detection for wezterm

### DIFF
--- a/src/modules/terminal.rs
+++ b/src/modules/terminal.rs
@@ -101,7 +101,7 @@ const KNOWN_TERMS: &[&str] = &[
     "tilix",
     "st",
     "hyper",
-    "wezterm",
+    "wezterm-gui",
     "gnome-terminal-server",
     "qterminal",
     "terminology",
@@ -200,6 +200,10 @@ pub fn get_terminal(config: &Configuration, package_managers: &ManagerInfo) -> R
         // Fix for elementaryos terminal being shitty
         if terminal.name.trim() == "io.elementary.terminal" {
             terminal.name = "Elementary Terminal".to_string();
+        }
+        // Fix for wezterm CLI being a proxy for wezterm GUI
+        if terminal.name.trim() == "wezterm-gui" {
+            terminal.name = "wezterm".to_string();
         }
     }
 


### PR DESCRIPTION
Terminal detection was not working with WezTerm because its process name is `wezterm-gui`; fixed by adding it to `KNOWN_TERMS`.

The name change (`wezterm-gui` to `wezterm`) is added to match the package name, but also to properly query version. For example, on Arch `wezterm --version` returns the actual version, while `wezterm-gui --version` returns "someone forgot to call assign_version_info".