### PR TITLE
Accurate AMD GPU detection

### DIFF
--- a/src/modules/gpu.rs
+++ b/src/modules/gpu.rs
@@ -186,7 +186,11 @@ fn fill_from_pcisysfile(gpus: &mut Vec<GPUInfo>, amd_accuracy: bool, ignore_disa
             // TODO: Just directly search AMD, not the first pci.ids file
             gpu.vendor = device_data.0;
             if vendor_id == "1002" && amd_accuracy { // AMD
-                gpu.model = match search_amd_model(&device_id)? {
+                let revision_id: String = match util::file_read(&d.path().join("revision")) {
+                    Ok(r) => r[2..].trim().to_string(),
+                    Err(e) => return Err(ModuleError::new("GPU", format!("Can't read from file: {}", e))),
+                };
+                gpu.model = match search_amd_model(&device_id, &revision_id)? {
                     Some(r) => r,
                     None => device_data.1,
                 };
@@ -265,8 +269,7 @@ fn search_pci_ids(vendor: &str, device: &str) -> Result<(String, String), Module
 
     Ok((vendor_result.to_string(), device_result.to_string()))
 }
-// TODO: Revision ID searching too
-fn search_amd_model(device: &str) -> Result<Option<String>, ModuleError> {
+fn search_amd_model(device: &str, revision: &str) -> Result<Option<String>, ModuleError> {
     let ids_path: &Path = match util::find_first_path_exists(vec![
         Path::new("/usr/share/libdrm/amdgpu.ids")
     ]) {
@@ -281,7 +284,7 @@ fn search_amd_model(device: &str) -> Result<Option<String>, ModuleError> {
     let buffer: BufReader<File> = BufReader::new(file);
 
     let mut device_result: String = String::new();
-    let dev_term: String = device.to_lowercase().to_string();
+    let dev_term: String = format!("{},\t{},\t", device, revision).to_lowercase().to_string();
     for line in buffer.lines() { 
         if line.is_err() {
             continue;
@@ -293,7 +296,7 @@ fn search_amd_model(device: &str) -> Result<Option<String>, ModuleError> {
         }
 
         if line.to_lowercase().starts_with(&dev_term) {
-            device_result = line.split('\t').nth(2).unwrap().trim().to_string();
+            device_result = line[dev_term.len()..].to_string();
             break
         }
     }

--- a/src/modules/gpu.rs
+++ b/src/modules/gpu.rs
@@ -178,24 +178,21 @@ fn fill_from_pcisysfile(gpus: &mut Vec<GPUInfo>, amd_accuracy: bool, ignore_disa
                 Ok(r) => r[2..].trim().to_string(),
                 Err(e) => return Err(ModuleError::new("GPU", format!("Can't read from file: {}", e))),
             };
-            let device_data: (String, String) = match search_pci_ids(&vendor_id, &device_id) {
-                Ok(r) => r,
-                Err(e) => return Err(e)
-            };
-
-            // TODO: Just directly search AMD, not the first pci.ids file
-            gpu.vendor = device_data.0;
             if vendor_id == "1002" && amd_accuracy { // AMD
+                gpu.vendor = String::from("Advanced Micro Devices, Inc. [AMD/ATI]");
                 let revision_id: String = match util::file_read(&d.path().join("revision")) {
                     Ok(r) => r[2..].trim().to_string(),
                     Err(e) => return Err(ModuleError::new("GPU", format!("Can't read from file: {}", e))),
                 };
-                gpu.model = match search_amd_model(&device_id, &revision_id)? {
-                    Some(r) => r,
-                    None => device_data.1,
-                };
-            } else {
-                gpu.model = device_data.1;
+                if let Some(r) = search_amd_model(&device_id, &revision_id)? {
+                    gpu.model = r;
+                }
+            }
+            if gpu.model == "Unknown" {
+                (gpu.vendor, gpu.model) = match search_pci_ids(&vendor_id, &device_id) {
+                    Ok(r) => r,
+                    Err(e) => return Err(e),
+                }
             }
         }
 


### PR DESCRIPTION
Add search by revision ID in `amdgpu.ids`. If found there, skip searching in the generic `pci.ids`.