### PR TITLE
Alleviate some borrow-checker pain -- Loading built-in ASCII art no longer creates a deep-copy.

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -1,13 +1,9 @@
 use std::{borrow::Cow, cmp::min};
 
-use colored::{ColoredString, Colorize};
+use colored::Colorize;
 use serde::Deserialize;
 
-use crate::{
-    ascii_art,
-    config_manager::{self, Configuration},
-    formatter::CrabFetchColor,
-};
+use crate::{ascii_art, config_manager::{self, Configuration}, formatter::CrabFetchColor};
 
 #[derive(Deserialize)]
 pub struct AsciiConfiguration {
@@ -20,14 +16,14 @@ pub struct AsciiConfiguration {
     // Done this way because I kid you not I could not find a way to make an multi-type thing for
     // the Config crate
     pub solid_color: CrabFetchColor,
-    pub band_colors: Vec<CrabFetchColor>,
+    pub band_colors: Vec<CrabFetchColor>
 }
 #[derive(Debug, Deserialize, PartialEq)]
 pub enum AsciiMode {
     Raw,
     OS,
     Solid,
-    Band,
+    Band
 }
 
 // Return type is the ascii & the maximum length of it
@@ -40,7 +36,7 @@ pub fn find_ascii(os: &str, ignore_custom: bool) -> (Cow<'_, str>, u16) {
                 let stripped = strip_ansi_escapes::strip_str(x);
                 let len: usize = stripped.chars().count();
                 if len > length as usize {
-                    length = u16::try_from(len).expect("Unable to convert length to u16")
+                    length = u16::try_from(len).expect("Unable to convert length to u16");
                 }
             });
             return (Cow::Owned(user_override), length);
@@ -74,12 +70,7 @@ pub fn find_ascii(os: &str, ignore_custom: bool) -> (Cow<'_, str>, u16) {
     (Cow::Borrowed(art), max_len)
 }
 
-pub fn get_ascii_line(
-    current_line: usize,
-    ascii_split: &[&str],
-    target_length: u16,
-    config: &Configuration,
-) -> String {
+pub fn get_ascii_line(current_line: usize, ascii_split: &[&str], target_length: u16, config: &Configuration) -> String {
     let mut line: String = String::new();
 
     if ascii_split.len() > current_line {
@@ -95,7 +86,7 @@ pub fn get_ascii_line(
         line = match config.ascii.mode {
             AsciiMode::Raw => line,
             AsciiMode::OS | AsciiMode::Solid => color_solid(&line, config), // main func sets the solid color to be the os color in the OS's case
-            AsciiMode::Band => color_band_vertical(&line, current_line, ascii_split.len(), config),
+            AsciiMode::Band => color_band_vertical(&line, current_line, ascii_split.len(), config)
         }
     }
 
@@ -110,29 +101,16 @@ fn color_solid(line: &str, config: &Configuration) -> String {
     config.ascii.solid_color.color_string(line).to_string()
 }
 
-#[allow(
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss
-)]
-fn color_band_vertical(
-    line: &str,
-    current_line: usize,
-    ascii_length: usize,
-    config: &Configuration,
-) -> String {
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn color_band_vertical(line: &str, current_line: usize, ascii_length: usize, config: &Configuration) -> String {
     let percentage: f32 = current_line as f32 / (ascii_length - 1) as f32;
     let total_colors: usize = config.ascii.band_colors.len();
-    let index: usize = min(
-        (((total_colors - 1) as f32) * percentage).round() as usize,
-        total_colors - 1,
-    );
+    let index: usize = min((((total_colors - 1) as f32) * percentage).round() as usize, total_colors - 1);
 
-    let colored: ColoredString = config
-        .ascii
+    config.ascii
         .band_colors
         .get(index as usize)
         .unwrap()
-        .color_string(line);
-    colored.to_string()
+        .color_string(line)
+        .to_string()
 }

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -155,19 +155,15 @@ pub fn parse(location_override: &Option<String>, module_override: &Option<String
 fn find_file_in_config_dir(path: &str) -> Option<PathBuf> {
     // Tries $XDG_CONFIG_HOME/CrabFetch before backing up to $HOME/.config/CrabFetch
     let mut paths: Vec<PathBuf> = Vec::new();
-    let mut temp_var_to_shut_up_the_borrow_checker: String;
-    if let Ok(config_home) = env::var("XDG_CONFIG_HOME") {
-        temp_var_to_shut_up_the_borrow_checker = config_home;
-        temp_var_to_shut_up_the_borrow_checker.push_str("/CrabFetch/");
-        temp_var_to_shut_up_the_borrow_checker.push_str(path);
-        paths.push(PathBuf::from(temp_var_to_shut_up_the_borrow_checker));
+    if let Ok(mut config_home) = env::var("XDG_CONFIG_HOME") {
+        config_home.push_str("/CrabFetch/");
+        config_home.push_str(path);
+        paths.push(PathBuf::from(config_home));
     }
-    let mut temp_var_to_shut_up_the_borrow_checker: String;
-    if let Ok(user_home) = env::var("HOME") {
-        temp_var_to_shut_up_the_borrow_checker = user_home;
-        temp_var_to_shut_up_the_borrow_checker.push_str("/.config/CrabFetch/");
-        temp_var_to_shut_up_the_borrow_checker.push_str(path);
-        paths.push(PathBuf::from(temp_var_to_shut_up_the_borrow_checker));
+    if let Ok(mut user_home) = env::var("HOME") {
+        user_home.push_str("/.config/CrabFetch/");
+        user_home.push_str(path);
+        paths.push(PathBuf::from(user_home));
     }
 
     util::find_first_pathbuf_exists(paths)
@@ -179,10 +175,7 @@ pub fn check_for_ascii_override() -> Option<String> {
         return None;
     }
 
-    match util::file_read(&path) {
-        Ok(r) => Some(r),
-        Err(_) => None,
-    }
+    util::file_read(&path).ok()
 }
 
 pub fn generate_config_file(location_override: Option<String>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 use std::process::{Command, Output};
 use std::time::Duration;
 use std::{cmp::max, env, process::exit, time::Instant};
+use std::borrow::Cow;
 
 use ascii::AsciiMode;
 use common_sources::gtk::GTKSettingsCache;
@@ -728,7 +729,7 @@ fn main() {
     let mut ascii_target_length: u16 = 0;
     // Prolong the lifetime of the buffer to the end of `main`:
     // `ascii_split` contains slices that view it.
-    let mut _ascii_buf: ascii::AsciiArtBuf = ascii::AsciiArtBuf::Empty;
+    let mut _ascii_buf: Cow<'_, str> = Cow::Borrowed("");
 
     if config.ascii.display {
         if known_outputs.os.is_none() {
@@ -739,13 +740,13 @@ fn main() {
 
         if let Some(Ok(os_outs)) = known_outputs.os.as_ref() {
             // Calculate the ASCII stuff while we're here
-            let (ascii_art, ascii_max_len): (ascii::AsciiArtBuf, u16) = match args.distro_override.as_ref() {
+            let (ascii_art, ascii_max_len): (Cow<'_, str>, u16) = match args.distro_override.as_ref() {
                 Some(over) => ascii::find_ascii(over, args.ignore_custom_ascii),
                 None => ascii::find_ascii(&os_outs.distro_id, args.ignore_custom_ascii),
             };
             _ascii_buf = ascii_art;
 
-            ascii_split = _ascii_buf.as_str().split('\n').filter(|x| x.trim() != "").collect();
+            ascii_split = _ascii_buf.split('\n').filter(|x| x.trim() != "").collect();
             ascii_length = ascii_split.len();
             ascii_target_length = ascii_max_len + config.ascii.margin;
         }


### PR DESCRIPTION
Presently, the ASCII art-loading code creates an unnecessary copy just to sate the type system. This PR fixes this issue by using `std::borrow::Cow` to capture the idea of a value that could be either `Owned` (in the case of the user-provided config) or `Borrowed` (in the case of loading the `&'static str`s in the binary).